### PR TITLE
ported uri utils with minor refactor and added tests

### DIFF
--- a/src/AndcultureCode.CSharp.Extensions/StringExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/StringExtensions.cs
@@ -33,6 +33,15 @@ namespace AndcultureCode.CSharp.Extensions
         }
 
         /// <summary>
+        /// Determines if the supplied string is not a valid HTTP or HTTPS Url
+        ///
+        /// Uses the native Uri class
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static bool IsInvalidHttpUrl(this string source) => !source.IsValidHttpUrl();
+
+        /// <summary>
         /// Determines if the supplied string is an email address
         /// </summary>
         /// <param name="email"></param>
@@ -70,6 +79,28 @@ namespace AndcultureCode.CSharp.Extensions
                 @"(?(\[)(\[(\d{1,3}\.){3}\d{1,3}\])|(([0-9a-z][-0-9a-z]*[0-9a-z]*\.)+[a-z0-9][\-a-z0-9]{0,22}[a-z0-9]))$",
                 RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
 
+        }
+
+        /// <summary>
+        /// Determines if the supplied string is a valid HTTP or HTTPS url
+        ///
+        /// Uses the native Uri class
+        /// </summary>
+        /// <param name="source"></param>
+        public static bool IsValidHttpUrl(this string source)
+        {
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                return false;
+            }
+
+            var validUriSchemes = new[]
+            {
+                Uri.UriSchemeHttp,
+                Uri.UriSchemeHttps
+            };
+
+            return Uri.TryCreate(source, UriKind.Absolute, out var uriResult) && validUriSchemes.Contains(uriResult.Scheme);
         }
 
         /// <summary>

--- a/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
@@ -151,14 +151,14 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         [Fact]
-        public void IsValidHttpUrl_With_Valid_Url_Scheme_Returns_True()
+        public void IsValidHttpUrl_With_Http_Url_Scheme_Returns_True()
         {
             // Arrange & Act & Assert
             "http://www.google.com".IsValidHttpUrl().ShouldBeTrue();
         }
 
         [Fact]
-        public void IsValidHttpUrl_With_Https_Url_Returns_True()
+        public void IsValidHttpUrl_With_Https_Url_Scheme_Returns_True()
         {
             // Arrange & Act & Assert
             "https://www.google.com".IsValidHttpUrl().ShouldBeTrue();

--- a/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
@@ -66,6 +66,39 @@ namespace AndcultureCode.CSharp.Extensions.Tests
 
         #endregion AsIndentedJson
 
+        #region IsInvalidHttpUrl
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void IsInvalidHttpUrl_When_Url_NullOrWhiteSpace_Returns_False(string url)
+        {
+            url.IsInvalidHttpUrl().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsInValidHttpUrl_With_Invalid_Url_Returns_True()
+        {
+            // arrange & act & assert
+            "www.google.com".IsInvalidHttpUrl().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsInValidHttpUrl_With_Valid_Url_Returns_False()
+        {
+            // arrange & act & assert
+            "http://www.google.com".IsInvalidHttpUrl().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsInValidHttpUrl_With_Invalid_Uri_Scheme_Returns_True()
+        {
+            // arrange & act & assert
+            "ftp://www.google.com".IsInvalidHttpUrl().ShouldBeTrue();
+        }
+
+        #endregion
 
         #region IsValidEmail
 
@@ -106,6 +139,46 @@ namespace AndcultureCode.CSharp.Extensions.Tests
 
         #endregion IsValidEmail
 
+        #region IsValidHttpUrl
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void IsValidHttpUrl_When_Url_NullOrWhiteSpace_Returns_False(string url)
+        {
+            url.IsValidHttpUrl().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsValidHttpUrl_With_Valid_Url_Returns_True()
+        {
+            // arrange & act & assert
+            "http://www.google.com".IsValidHttpUrl().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsValidHttpUrl_With_Https_Url_Returns_True()
+        {
+            // arrange & act & assert
+            "https://www.google.com".IsValidHttpUrl().ShouldBeTrue();
+        }
+
+        [Fact]
+        public void IsValidHttpUrl_With_Incomplete_Url_Returns_False()
+        {
+            // arrange & act & assert
+            "www.google.com".IsValidHttpUrl().ShouldBeFalse();
+        }
+
+        [Fact]
+        public void IsValidHttpUrl_With_Invalid_Url_Scheme_Returns_False()
+        {
+            // arrange & act & assert
+            "ftp://www.google.com".IsValidHttpUrl().ShouldBeFalse();
+        }
+
+        #endregion
 
         #region ToBoolean
 

--- a/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/StringExtensionsTests.cs
@@ -78,23 +78,23 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         [Fact]
-        public void IsInValidHttpUrl_With_Invalid_Url_Returns_True()
+        public void IsInValidHttpUrl_With_No_Url_Scheme_Returns_True()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "www.google.com".IsInvalidHttpUrl().ShouldBeTrue();
         }
 
         [Fact]
-        public void IsInValidHttpUrl_With_Valid_Url_Returns_False()
+        public void IsInValidHttpUrl_With_Valid_Url_Scheme_Returns_False()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "http://www.google.com".IsInvalidHttpUrl().ShouldBeFalse();
         }
 
         [Fact]
         public void IsInValidHttpUrl_With_Invalid_Uri_Scheme_Returns_True()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "ftp://www.google.com".IsInvalidHttpUrl().ShouldBeTrue();
         }
 
@@ -151,30 +151,30 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         [Fact]
-        public void IsValidHttpUrl_With_Valid_Url_Returns_True()
+        public void IsValidHttpUrl_With_Valid_Url_Scheme_Returns_True()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "http://www.google.com".IsValidHttpUrl().ShouldBeTrue();
         }
 
         [Fact]
         public void IsValidHttpUrl_With_Https_Url_Returns_True()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "https://www.google.com".IsValidHttpUrl().ShouldBeTrue();
         }
 
         [Fact]
         public void IsValidHttpUrl_With_Incomplete_Url_Returns_False()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "www.google.com".IsValidHttpUrl().ShouldBeFalse();
         }
 
         [Fact]
         public void IsValidHttpUrl_With_Invalid_Url_Scheme_Returns_False()
         {
-            // arrange & act & assert
+            // Arrange & Act & Assert
             "ftp://www.google.com".IsValidHttpUrl().ShouldBeFalse();
         }
 


### PR DESCRIPTION
As requested, this PR ports the existing UriUtilities code from the NFPA project to the StringExtensions class.

A minor refactor occurred... the original NFPA version made two comparisons on two different UrlSchemes. To improve performance and extensibility, the two UrlSchemes were added to a collection of valid schemes, and that collection is searched against. Tests were added to cover this refactor.