### PR TITLE
Ported IQueryable ordering extensions (OrderBy & ThenBy) #26

### DIFF
--- a/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
+++ b/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
@@ -1,101 +1,109 @@
 <a name='assembly'></a>
+
 # AndcultureCode.CSharp.Extensions
 
 ## Contents
 
-- [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes')
-  - [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN')
-  - [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID')
-  - [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS')
-  - [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE')
-  - [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID')
-  - [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID')
-- [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions')
-  - [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)')
-  - [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)')
-  - [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)')
-  - [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)')
-  - [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)')
-  - [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)')
-  - [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)')
-- [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions 'AndcultureCode.CSharp.Extensions.DateExtensions')
-  - [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)')
-  - [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)')
-  - [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- 'AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)')
-  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)')
-  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)')
-  - [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)')
-  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)')
-  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)')
-- [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions 'AndcultureCode.CSharp.Extensions.DictionaryExtensions')
-  - [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- 'AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)')
-- [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions 'AndcultureCode.CSharp.Extensions.ExpressionExtensions')
-  - [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-  - [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-  - [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-- [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions')
-  - [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR')
-  - [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-  - [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-  - [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)')
-  - [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)')
-  - [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-- [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions')
-  - [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)')
-- [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions')
-  - [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE')
-  - [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY')
-  - [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE')
-  - [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY')
-  - [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)')
-  - [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)')
-  - [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)')
-- [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions')
-  - [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})')
-  - [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
-  - [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})')
-  - [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
-  - [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)')
-  - [Join(list,keyValueDelimiter,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)')
-  - [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)')
-  - [Join(pair,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)')
-  - [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})')
-  - [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)')
-  - [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})')
-- [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions 'AndcultureCode.CSharp.Extensions.IQueryableExtensions')
-  - [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})')
-  - [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})')
-  - [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})')
-  - [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)')
-  - [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})')
-- [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions 'AndcultureCode.CSharp.Extensions.StringExtensions')
-  - [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)')
-  - [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)')
-  - [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)')
-  - [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)')
-  - [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)')
-  - [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)')
-  - [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)')
-  - [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)')
-  - [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)')
-  - [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- 'AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)')
-- [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions 'AndcultureCode.CSharp.Extensions.TypeExtensions')
-  - [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)')
-  - [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)')
-  - [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)')
-  - [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)')
-  - [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)')
-  - [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)')
-  - [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)')
-  - [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
-  - [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
+-   [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes")
+    -   [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN")
+    -   [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID")
+    -   [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS")
+    -   [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE")
+    -   [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID")
+    -   [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID")
+-   [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions")
+    -   [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)")
+    -   [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)")
+    -   [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)")
+    -   [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)")
+    -   [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)")
+    -   [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)")
+    -   [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)")
+-   [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions "AndcultureCode.CSharp.Extensions.DateExtensions")
+    -   [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)")
+    -   [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)")
+    -   [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- "AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)")
+    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)")
+    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)")
+    -   [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)")
+    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)")
+    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)")
+-   [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions "AndcultureCode.CSharp.Extensions.DictionaryExtensions")
+    -   [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- "AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)")
+-   [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions "AndcultureCode.CSharp.Extensions.ExpressionExtensions")
+    -   [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+    -   [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+    -   [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+-   [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions "AndcultureCode.CSharp.Extensions.HttpRequestExtensions")
+    -   [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR")
+    -   [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+    -   [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+    -   [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)")
+    -   [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)")
+    -   [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+-   [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions")
+    -   [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)")
+-   [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions")
+    -   [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE")
+    -   [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY")
+    -   [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE")
+    -   [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY")
+    -   [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)")
+    -   [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)")
+    -   [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)")
+-   [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions "AndcultureCode.CSharp.Extensions.IEnumerableExtensions")
+    -   [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
+    -   [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
+    -   [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)")
+    -   [Join(list,keyValueDelimiter,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)")
+    -   [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)")
+    -   [Join(pair,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)")
+    -   [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)")
+    -   [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})")
+-   [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions "AndcultureCode.CSharp.Extensions.IQueryableExtensions")
+    -   [AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.AppendOrderByExpression``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection,System.Boolean)")
+    -   [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})")
+    -   [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})")
+    -   [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [OrderBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.OrderBy``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
+    -   [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})")
+    -   [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)")
+    -   [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})")
+    -   [ThenBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.ThenBy``1(System.Linq.IOrderedQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
+-   [OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")
+    -   [Ascending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Ascending")
+    -   [Descending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Descending")
+-   [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions "AndcultureCode.CSharp.Extensions.StringExtensions")
+    -   [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)")
+    -   [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)")
+    -   [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)")
+    -   [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)")
+    -   [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)")
+    -   [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)")
+    -   [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)")
+    -   [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- "AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)")
+    -   [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- "AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)")
+    -   [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- "AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)")
+-   [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions "AndcultureCode.CSharp.Extensions.TypeExtensions")
+    -   [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)")
+    -   [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)")
+    -   [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)")
+    -   [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)")
+    -   [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)")
+    -   [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)")
+    -   [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)")
+    -   [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
+    -   [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
 
 <a name='T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes'></a>
+
 ## ApiClaimTypes `type`
 
 ##### Namespace
@@ -106,9 +114,10 @@ AndcultureCode.CSharp.Core.Constants
 
 Commonly used Claim types for APIs
 
- TODO: Migrate to AndcultureCode.CSharp.Core
+TODO: Migrate to AndcultureCode.CSharp.Core
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN'></a>
+
 ### IS_SUPER_ADMIN `constants`
 
 ##### Summary
@@ -116,6 +125,7 @@ Commonly used Claim types for APIs
 Is the current user elevated to super admin
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID'></a>
+
 ### ROLE_ID `constants`
 
 ##### Summary
@@ -123,6 +133,7 @@ Is the current user elevated to super admin
 Active Role Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS'></a>
+
 ### ROLE_IDS `constants`
 
 ##### Summary
@@ -130,6 +141,7 @@ Active Role Id
 Available Role Ids
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE'></a>
+
 ### ROLE_TYPE `constants`
 
 ##### Summary
@@ -137,6 +149,7 @@ Available Role Ids
 Active Role Type
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID'></a>
+
 ### USER_ID `constants`
 
 ##### Summary
@@ -144,6 +157,7 @@ Active Role Type
 Current User Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID'></a>
+
 ### USER_LOGIN_ID `constants`
 
 ##### Summary
@@ -151,6 +165,7 @@ Current User Id
 Current User Login Id
 
 <a name='T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions'></a>
+
 ## ClaimsPrincipalExtensions `type`
 
 ##### Namespace
@@ -162,6 +177,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for ClaimsPrincipal
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsAuthenticated(principal) `method`
 
 ##### Summary
@@ -170,15 +186,14 @@ Whether the current user is authenticated
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsSuperAdmin(principal) `method`
 
 ##### Summary
@@ -187,15 +202,14 @@ Retrieves whether the user is a super admin by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsUnauthenticated(principal) `method`
 
 ##### Summary
@@ -204,15 +218,14 @@ Whether the current user is unauthenticated
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### RoleId(principal) `method`
 
 ##### Summary
@@ -221,15 +234,14 @@ Retrieves user's current role id by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### RoleIds(principal) `method`
 
 ##### Summary
@@ -238,15 +250,14 @@ Retrieves user's role ids by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### UserId(principal) `method`
 
 ##### Summary
@@ -255,15 +266,14 @@ Retrieves user's id by way of identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### UserLoginId(principal) `method`
 
 ##### Summary
@@ -272,15 +282,14 @@ Retrieves user's UserLoginId from identity claims.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-DateExtensions'></a>
+
 ## DateExtensions `type`
 
 ##### Namespace
@@ -292,6 +301,7 @@ AndcultureCode.CSharp.Extensions
 DateTime/Offset Extensions
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset-'></a>
+
 ### AtEndOfDay(date) `method`
 
 ##### Summary
@@ -300,15 +310,14 @@ Sets and returns the time to 11:59:59 on the given DateTimeOffset.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
+| Name | Type                                                                                                                                            | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset-'></a>
+
 ### AtMidnight(date) `method`
 
 ##### Summary
@@ -318,15 +327,14 @@ Returns the midnight representation of the given DateTimeOffset.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
+| Name | Type                                                                                                                                            | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime-'></a>
+
 ### CalculateAge() `method`
 
 ##### Summary
@@ -338,6 +346,7 @@ Convenience method to calculate an age from a birthdate
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset-'></a>
+
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -350,6 +359,7 @@ LINQ doesn't like optional parameters on methods used in expressions
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean-'></a>
+
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -361,6 +371,7 @@ Provides filtering method for date ranges (excluding time portions)
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32-'></a>
+
 ### SetTime(date,hour,minute,second) `method`
 
 ##### Summary
@@ -369,18 +380,17 @@ Sets the hour, minute, and second on the given DateTimeOffset with the supplied 
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
-| hour | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
-| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
-| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| Name   | Type                                                                                                                                            | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date   | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
+| hour   | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
+| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
+| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32-'></a>
+
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -392,6 +402,7 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32-'></a>
+
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -403,6 +414,7 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='T-AndcultureCode-CSharp-Extensions-DictionaryExtensions'></a>
+
 ## DictionaryExtensions `type`
 
 ##### Namespace
@@ -414,6 +426,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for Dictionary
 
 <a name='M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean-'></a>
+
 ### Merge\`\`2(left,right,takeLastKey) `method`
 
 ##### Summary
@@ -423,25 +436,24 @@ or last occurrence will be used. See 'takeLastKey'
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| left | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into. |
-| right | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into the left dictionary. |
-| takeLastKey | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Determines whether the value of the last occurrence of a key is used as the final value
-when duplicates are encountered. If false, uses the value of the first occurrence. |
+| Name                                                                               | Type                                                                                                                                                                                                                  | Description                                                                             |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| left                                                                               | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into.                                                           |
+| right                                                                              | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into the left dictionary.                                       |
+| takeLastKey                                                                        | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                            | Determines whether the value of the last occurrence of a key is used as the final value |
+| when duplicates are encountered. If false, uses the value of the first occurrence. |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| TKey |  |
-| TValue |  |
+| Name   | Description |
+| ------ | ----------- |
+| TKey   |             |
+| TValue |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-ExpressionExtensions'></a>
+
 ## ExpressionExtensions `type`
 
 ##### Namespace
@@ -453,6 +465,7 @@ AndcultureCode.CSharp.Extensions
 Expression extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### AndAlso\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -461,22 +474,21 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### AndAlso\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -485,24 +497,23 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### OrElse\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -511,22 +522,21 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### OrElse\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -535,24 +545,23 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### Or\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -561,22 +570,21 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### Or\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -585,24 +593,23 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions'></a>
+
 ## HttpRequestExtensions `type`
 
 ##### Namespace
@@ -614,6 +621,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for HttpRequest
 
 <a name='F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR'></a>
+
 ### X_FORWARDED_FOR `constants`
 
 ##### Summary
@@ -621,26 +629,26 @@ Extension methods for HttpRequest
 Standard X-Header for forwarding IP addresses in varying infrastructures
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### GetCookie(request,name) `method`
 
 ##### Summary
 
 Returns the specified cookie by name
 
- If no cookie is found, returns null
+If no cookie is found, returns null
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to pull the cookie from |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to be returned |
+| Name    | Type                                                                                                                      | Description                           |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to pull the cookie from   |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to be returned |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### GetHeader(request,name) `method`
 
 ##### Summary
@@ -649,12 +657,13 @@ Attempts to retrieve requested header value
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Header name/key |
+| Name    | Type                                                                                                                      | Description     |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |                 |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | Header name/key |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest-'></a>
+
 ### GetIpAddress(request) `method`
 
 ##### Summary
@@ -664,15 +673,14 @@ Ensure you have 'AddForwardedHeaders' enabled in startup.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
+| Name    | Type                                                                                                                      | Description |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest-'></a>
+
 ### GetUserAgent() `method`
 
 ##### Summary
@@ -684,26 +692,26 @@ Requesting user's agent
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### HasCookie(request,name) `method`
 
 ##### Summary
 
 Returns whether or not the specified cookie is found in the request
 
- If the cookie is found but its value is null/whitespace, it will return false.
+If the cookie is found but its value is null/whitespace, it will return false.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to check for the cookie |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to check for |
+| Name    | Type                                                                                                                      | Description                         |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to check for the cookie |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to check for |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions'></a>
+
 ## HttpResponseMessageExtensions `type`
 
 ##### Namespace
@@ -715,6 +723,7 @@ AndcultureCode.CSharp.Extensions
 HttpResponseMessage extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage-'></a>
+
 ### FromJson\`\`1(response) `method`
 
 ##### Summary
@@ -723,21 +732,20 @@ Deserializes http response into supplied object
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage 'System.Net.Http.HttpResponseMessage') |  |
+| Name     | Type                                                                                                                                                                                      | Description |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage "System.Net.Http.HttpResponseMessage") |             |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions'></a>
+
 ## IConfigurationRootExtensions `type`
 
 ##### Namespace
@@ -749,6 +757,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for IConfigurationRoot
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE'></a>
+
 ### CONFIGURATION_VERSION_DEVELOPMENT_VALUE `constants`
 
 ##### Summary
@@ -756,6 +765,7 @@ Extension methods for IConfigurationRoot
 Version value when application is run in development environment
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY'></a>
+
 ### CONFIGURATION_VERSION_KEY `constants`
 
 ##### Summary
@@ -763,6 +773,7 @@ Version value when application is run in development environment
 Key value for build version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE'></a>
+
 ### CONFIGURATION_VERSION_TEMPLATE `constants`
 
 ##### Summary
@@ -770,6 +781,7 @@ Key value for build version number
 Template string replaced with current version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY'></a>
+
 ### DEFAULT_DATABASE_KEY `constants`
 
 ##### Summary
@@ -777,6 +789,7 @@ Template string replaced with current version number
 Default connection string database key
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String-'></a>
+
 ### GetDatabaseConnectionString(configuration,databaseKey) `method`
 
 ##### Summary
@@ -785,12 +798,13 @@ Retrieves web application's primary database connection string
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
-| databaseKey | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
+| databaseKey   | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                   |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot-'></a>
+
 ### GetDatabaseName(configuration) `method`
 
 ##### Summary
@@ -799,11 +813,12 @@ Retrieves the database name of the primary database connection string
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean-'></a>
+
 ### GetVersion(configuration,isDevelopment) `method`
 
 ##### Summary
@@ -812,16 +827,15 @@ Loads and conditionally updates the Version number based upon environment
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
-| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
+| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions'></a>
+
 ## IEnumerableExtensions `type`
 
 ##### Namespace
@@ -833,6 +847,7 @@ AndcultureCode.CSharp.Extensions
 IEnumerable extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### IsEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -841,21 +856,20 @@ Determines if the source list is empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
+| Name   | Type                                                                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+
 ### IsEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -864,22 +878,21 @@ Determines if the source list is empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
-| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{``0,System.Boolean}') |  |
+| Name      | Type                                                                                                                                                                                                           | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source    | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
+| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func "System.Func{``0,System.Boolean}")                                                    |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### IsNullOrEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -888,21 +901,20 @@ Determines if the source list is null or empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
+| Name   | Type                                                                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+
 ### IsNullOrEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -911,22 +923,21 @@ Determines if the source list is null or empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
-| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func 'System.Func{``0,System.Boolean}') |  |
+| Name      | Type                                                                                                                                                                                                           | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source    | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
+| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func "System.Func{``0,System.Boolean}")                                                    |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String-'></a>
+
 ### Join(list,delimiter) `method`
 
 ##### Summary
@@ -935,16 +946,15 @@ Convenience method so joining strings reads better :)
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| list | [System.Collections.Generic.IEnumerable{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{System.String}') |  |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name      | Type                                                                                                                                                                                                                             | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| list      | [System.Collections.Generic.IEnumerable{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{System.String}") |             |
+| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                          |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String-'></a>
+
 ### Join(list,keyValueDelimiter,delimiter) `method`
 
 ##### Summary
@@ -953,17 +963,16 @@ Convenience method for joining dictionary key values into a string
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| list | [System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}') |  |
-| keyValueDelimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name              | Type                                                                                                                                                                                                                                                                                                                                           | Description |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| list              | [System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}") |             |
+| keyValueDelimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                                                                                                        |             |
+| delimiter         | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                                                                                                        |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String-'></a>
+
 ### Join(list,delimiter) `method`
 
 ##### Summary
@@ -972,16 +981,15 @@ Convenience method so joining a list of strings
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| list | [System.Collections.Generic.List{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List 'System.Collections.Generic.List{System.String}') |  |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name      | Type                                                                                                                                                                                                        | Description |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| list      | [System.Collections.Generic.List{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List "System.Collections.Generic.List{System.String}") |             |
+| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                     |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String-'></a>
+
 ### Join(pair,delimiter) `method`
 
 ##### Summary
@@ -990,16 +998,15 @@ Convenience method for joining key value pairs
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| pair | [System.Collections.Generic.KeyValuePair{System.String,System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.KeyValuePair 'System.Collections.Generic.KeyValuePair{System.String,System.String}') |  |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name      | Type                                                                                                                                                                                                                                                            | Description |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| pair      | [System.Collections.Generic.KeyValuePair{System.String,System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.KeyValuePair "System.Collections.Generic.KeyValuePair{System.String,System.String}") |             |
+| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                         |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### PickRandom\`\`1(source) `method`
 
 ##### Summary
@@ -1008,17 +1015,18 @@ Returns a random value in the related IEnumerable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
+| Name   | Type                                                                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32-'></a>
+
 ### PickRandom\`\`1(source,count) `method`
 
 ##### Summary
@@ -1027,18 +1035,19 @@ Returns X number of random values in the related IEnumerable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
-| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| Name   | Type                                                                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
+| count  | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                                                                                           |             |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### Shuffle\`\`1(source) `method`
 
 ##### Summary
@@ -1047,17 +1056,18 @@ Returns source enumerable in randomized order
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable 'System.Collections.Generic.IEnumerable{``0}') |  |
+| Name   | Type                                                                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IQueryableExtensions'></a>
+
 ## IQueryableExtensions `type`
 
 ##### Namespace
@@ -1068,7 +1078,33 @@ AndcultureCode.CSharp.Extensions
 
 IQueryable extension methods
 
+<a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean-'></a>
+
+### AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy) `method`
+
+##### Summary
+
+Adds an additional sorting expression to the supplied IQueryable.
+
+##### Returns
+
+##### Parameters
+
+| Name                | Type                                                                                                                                                                                                          | Description                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| query               | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") | The IQueryable to add additional sorting to. |
+| propertyName        | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                       | The path to the property to order by (e.g. Path.To.Property).         |
+| direction           | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")          | Order by which to sort items.                                         |
+| isAdditionalOrderBy | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                    | Whether the order by is an addition to an existing OrderBy statement. |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T    |             |
+
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}-'></a>
+
 ### IsEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -1077,21 +1113,20 @@ Determines if the source list is empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### IsEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -1100,22 +1135,21 @@ Determines if the source list is empty (based on the given predicate)
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
+| Name      | Type                                                                                                                                                                                                                                                       | Description |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source    | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}")                                                                                             |
+| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}-'></a>
+
 ### IsNullOrEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -1124,21 +1158,20 @@ Determines if the source list is null or empty
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### IsNullOrEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -1147,22 +1180,45 @@ Determines if the source list is null or empty (based on the given predicate)
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
+| Name      | Type                                                                                                                                                                                                                                                       | Description |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source    | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}")                                                                                             |
+| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
+
+<a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
+
+### OrderBy\`\`1(query,propertyName,direction) `method`
+
+##### Summary
+
+Order by the string expression provided
+
+##### Returns
+
+##### Parameters
+
+| Name         | Type                                                                                                                                                                                                 | Description                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| query        | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}")                                       |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                              | Property names can be period delimitted to indicate nested objects |
+| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection") | Order by which to sort items.                                      |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}-'></a>
+
 ### PickRandom\`\`1(source) `method`
 
 ##### Summary
@@ -1171,17 +1227,18 @@ Returns a random value in the related IQueryable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32-'></a>
+
 ### PickRandom\`\`1(source,count) `method`
 
 ##### Summary
@@ -1190,18 +1247,19 @@ Returns X number of random values in the related IQueryable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
+| count  | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                                           |             |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}-'></a>
+
 ### Shuffle\`\`1(source) `method`
 
 ##### Summary
@@ -1210,17 +1268,70 @@ Returns source enumerable in randomized order
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
+
+<a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
+
+### ThenBy\`\`1(query,propertyName,direction) `method`
+
+##### Summary
+
+Order then by the string expression provided
+
+##### Returns
+
+##### Parameters
+
+| Name         | Type                                                                                                                                                                                                 | Description                                                        |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| query        | [System.Linq.IOrderedQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedQueryable "System.Linq.IOrderedQueryable{``0}")                  |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                              | Property names can be period delimitted to indicate nested objects |
+| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection") | Order by which to sort items.                                      |
+
+##### Generic Types
+
+| Name | Description |
+| ---- | ----------- |
+| T    |             |
+
+<a name='T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection'></a>
+
+## OrderByDirection `type`
+
+##### Namespace
+
+AndcultureCode.CSharp.Extensions.Enumerations
+
+##### Summary
+
+Directions for ordering items.
+
+<a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending'></a>
+
+### Ascending `constants`
+
+##### Summary
+
+Sorted in ascending order.
+
+<a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending'></a>
+
+### Descending `constants`
+
+##### Summary
+
+Sorted in descending order.
 
 <a name='T-AndcultureCode-CSharp-Extensions-StringExtensions'></a>
+
 ## StringExtensions `type`
 
 ##### Namespace
@@ -1232,6 +1343,7 @@ AndcultureCode.CSharp.Extensions
 String extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String-'></a>
+
 ### AsIndentedJson(str) `method`
 
 ##### Summary
@@ -1240,34 +1352,32 @@ Formats string for pretty printing of a JSON string
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| str | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name | Type                                                                                                                    | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| str  | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String-'></a>
+
 ### IsInvalidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is not a valid HTTP or HTTPS Url
 
- Uses the native Uri class
+Uses the native Uri class
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name   | Type                                                                                                                    | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String-'></a>
+
 ### IsNotValidGuid(guidString) `method`
 
 ##### Summary
@@ -1276,15 +1386,14 @@ Determine if supplied string is not a valid Guid
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name       | Type                                                                                                                    | Description |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String-'></a>
+
 ### IsValidEmail(email) `method`
 
 ##### Summary
@@ -1293,11 +1402,12 @@ Determines if the supplied string is an email address
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name  | Type                                                                                                                    | Description |
+| ----- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String-'></a>
+
 ### IsValidGuid(guidString) `method`
 
 ##### Summary
@@ -1306,30 +1416,30 @@ Determine if supplied string is a valid Guid
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name       | Type                                                                                                                    | Description |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String-'></a>
+
 ### IsValidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is a valid HTTP or HTTPS url
 
- Uses the native Uri class
+Uses the native Uri class
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name   | Type                                                                                                                    | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String-'></a>
+
 ### ToBoolean() `method`
 
 ##### Summary
@@ -1341,6 +1451,7 @@ Converts a string representation of a boolean into an actual boolean
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char-'></a>
+
 ### ToEnumerable\`\`1(input,separator) `method`
 
 ##### Summary
@@ -1349,16 +1460,15 @@ Converts a string of ints into an enumerable
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| input | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
-| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char 'System.Char') |  |
+| Name      | Type                                                                                                                    | Description |
+| --------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| input     | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char "System.Char")       |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32-'></a>
+
 ### ToInt(number,defaultValue) `method`
 
 ##### Summary
@@ -1371,12 +1481,13 @@ Converted string as an integer value
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| number | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | String that should be a number |
-| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Default value used if the number cannot be parse (0 is default) |
+| Name         | Type                                                                                                                    | Description                                                     |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| number       | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") | String that should be a number                                  |
+| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")    | Default value used if the number cannot be parse (0 is default) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type-'></a>
+
 ### TryChangeType(value,conversionType) `method`
 
 ##### Summary
@@ -1385,16 +1496,15 @@ Returns true or false if the value can be converted
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| value | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| Name           | Type                                                                                                                    | Description |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| value          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-TypeExtensions'></a>
+
 ## TypeExtensions `type`
 
 ##### Namespace
@@ -1406,6 +1516,7 @@ AndcultureCode.CSharp.Extensions
 Extensions for Type
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type-'></a>
+
 ### GetPublicConstantValues\`\`1() `method`
 
 ##### Summary
@@ -1417,6 +1528,7 @@ Retrieve all constant values for given type whose value matches type T
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String-'></a>
+
 ### GetPublicPropertyInfo(type,propertyName) `method`
 
 ##### Summary
@@ -1431,12 +1543,13 @@ The PropertyInfo for the property, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String-'></a>
+
 ### GetPublicPropertyValue(src,propertyName) `method`
 
 ##### Summary
@@ -1451,12 +1564,13 @@ The property value, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String-'></a>
+
 ### GetPublicPropertyValue\`\`1(src,propertyName) `method`
 
 ##### Summary
@@ -1471,12 +1585,13 @@ The property value, if it exists, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object-'></a>
+
 ### GetTypeName(obj) `method`
 
 ##### Summary
@@ -1485,15 +1600,14 @@ Returns the name the underlying type of any object
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| obj | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| Name | Type                                                                                                                    | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| obj  | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type-'></a>
+
 ### GetTypeName(type) `method`
 
 ##### Summary
@@ -1502,15 +1616,14 @@ Returns the full name of the type as well as the assembly qualified name
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| Name | Type                                                                                                              | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
+| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String-'></a>
+
 ### HasPublicProperty(type,propertyName) `method`
 
 ##### Summary
@@ -1524,12 +1637,13 @@ true if type has property with specified name, false otherwise
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
+
 ### WhereWithAttribute\`\`1() `method`
 
 ##### Summary
@@ -1542,6 +1656,7 @@ decorated with the TAttribute attribute at the class level.
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
+
 ### WhereWithoutAttribute\`\`1() `method`
 
 ##### Summary

--- a/src/AndcultureCode.CSharp.Extensions/Enumerations/OrderByDirection.cs
+++ b/src/AndcultureCode.CSharp.Extensions/Enumerations/OrderByDirection.cs
@@ -1,0 +1,13 @@
+namespace AndcultureCode.CSharp.Extensions.Enumerations
+{
+    /// <summary>
+    /// Directions for ordering items.
+    /// </summary>
+    public enum OrderByDirection
+    {
+        ///<summary>Sorted in ascending order.</summary>
+        Ascending,
+        ///<summary>Sorted in descending order.</summary>
+        Descending,
+    }
+}

--- a/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
+using AndcultureCode.CSharp.Extensions.Enumerations;
 
 namespace AndcultureCode.CSharp.Extensions
 {
@@ -44,6 +45,17 @@ namespace AndcultureCode.CSharp.Extensions
         public static bool IsNullOrEmpty<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) => source == null || source.IsEmpty(predicate);
 
         /// <summary>
+        /// Order by the string expression provided.
+        /// </summary>
+        /// <param name="query">The IOrderedQueryable to add additional sorting to.</param>
+        /// <param name="propertyName">The path to the property to order by (e.g. Path.To.Property).</param>
+        /// <param name="direction">Order by which to sort items.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> query,
+            string propertyName, OrderByDirection direction = OrderByDirection.Ascending) => query.AppendOrderByExpression(propertyName, direction, false);
+
+        /// <summary>
         /// Returns a random value in the related IQueryable list
         /// </summary>
         /// <param name="source"></param>
@@ -64,5 +76,56 @@ namespace AndcultureCode.CSharp.Extensions
         /// <param name="source"></param>
         /// <typeparam name="T"></typeparam>
         public static IQueryable<T> Shuffle<T>(this IQueryable<T> source) => source.OrderBy(x => Guid.NewGuid());
+
+        /// <summary>
+        /// Order then by the string expression provided.
+        /// </summary>
+        /// <param name="query">The IOrderedQueryable to add additional sorting to.</param>
+        /// <param name="propertyName">The path to the property to order by (e.g. Path.To.Property).</param>
+        /// <param name="direction">Order by which to sort items.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> query,
+            string propertyName, OrderByDirection direction = OrderByDirection.Ascending) => query.AppendOrderByExpression(propertyName, direction, true);
+
+        #region Private Methods
+
+        /// <summary>
+        /// Adds an additional sorting expression to the supplied IQueryable.
+        /// </summary>
+        /// <param name="query">The IQueryable to add additional sorting to.</param>
+        /// <param name="propertyName">The path to the property to order by (e.g. Path.To.Property).</param>
+        /// <param name="direction">Order by which to sort items.</param>
+        /// <param name="isAdditionalOrderBy">Whether the order by is an addition to an existing OrderBy statement.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        private static IOrderedQueryable<T> AppendOrderByExpression<T>(this IQueryable<T> query, string propertyName, OrderByDirection direction, bool isAdditionalOrderBy)
+        {
+            if (string.IsNullOrWhiteSpace(propertyName))
+            {
+                return (IOrderedQueryable<T>)query;
+            }
+
+            ParameterExpression param = Expression.Parameter(typeof(T), string.Empty);
+            Expression body = param;
+
+            foreach (var member in propertyName.Split('.'))
+            {
+                body = Expression.PropertyOrField(body, member);
+            }
+
+            bool isDescending = direction == OrderByDirection.Descending;
+            LambdaExpression sort = Expression.Lambda(body, param);
+            MethodCallExpression call = Expression.Call(
+                typeof(Queryable),
+                (!isAdditionalOrderBy ? "OrderBy" : "ThenBy") + (isDescending ? "Descending" : string.Empty),
+                new[] { typeof(T), body.Type },
+                query.Expression,
+                Expression.Quote(sort));
+
+            return (IOrderedQueryable<T>)query.Provider.CreateQuery<T>(call);
+        }
+
+        #endregion Private Methods
     }
 }

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using AndcultureCode.CSharp.Extensions.Enumerations;
 using Shouldly;
 using Xunit;
 
@@ -178,6 +180,126 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         #endregion IsNullOrEmpty (Given Predicate)
+
+        #region OrderBy
+
+        [Fact]
+        public void OrderBy_When_Property_DoesNotExist_Throws_ArgumentException()
+        {
+            // Arrange
+            var queryable = new List<string>().AsQueryable();
+            string badPropertyName = "test"; // <-- This property does not exist on the string type.
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => queryable.OrderBy<string>(badPropertyName));
+        }
+
+        [Fact]
+        public void OrderBy_When_List_IsEmpty_Returns_Empty_List()
+        {
+            // Arrange
+            var queryable = new List<DateTime>().AsQueryable();
+
+            // Act
+            var result = queryable.OrderBy<DateTime>("Day");
+
+            // Assert
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void OrderBy_When_Sorted_In_Ascending_Order_Returns_List_Ordered_Ascending()
+        {
+            // Arrange
+            var olderDate = DateTime.MinValue;
+            var newerDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { newerDate, olderDate }.AsQueryable();
+
+            // Act
+            var result = queryable.OrderBy<DateTime>("Year", OrderByDirection.Ascending);
+
+            // Assert
+            result.First().ShouldBe(olderDate);
+        }
+
+        [Fact]
+        public void OrderBy_When_Sorted_In_Descending_Order_Returns_List_Ordered_Descending()
+        {
+            // Arrange
+            var olderDate = DateTime.MinValue;
+            var newerDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { olderDate, newerDate }.AsQueryable();
+
+            // Act
+            var result = queryable.OrderBy<DateTime>("Year", OrderByDirection.Descending);
+
+            // Assert
+            result.First().ShouldBe(newerDate);
+        }
+
+        [Fact]
+        public void OrderBy_When_Not_Only_OrderBy_Should_Replace_Existing_OrderBy()
+        {
+            // Arrange
+            var olderDate = DateTime.MinValue;
+            var newerDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { newerDate, olderDate }.AsQueryable();
+            queryable.OrderByDescending(date => date.Year); // <-- This is the expression that should be replaced.
+
+            // Act
+            var result = queryable.OrderBy<DateTime>("Year", OrderByDirection.Ascending);
+
+            // Assert
+            result.First().ShouldBe(olderDate);
+        }
+
+        [Fact]
+        public void OrderBy_When_OrderByProperty_IsEmpty_Returns_Unsorted_List()
+        {
+            // Arrange
+            var queryable = new List<string> { "Test1", "Test2" }.AsQueryable();
+            string orderByProperty = string.Empty;
+
+            // Act
+            var result = queryable.OrderBy<string>(orderByProperty);
+
+            // Assert
+            result.ShouldBeSameAs(queryable);
+        }
+
+        [Fact]
+        public void OrderBy_When_OrderedAscending_With_Nested_Property_Returns_List_Ordered_Ascending()
+        {
+            // Arrange
+            var olderDate = DateTime.MinValue;
+            var newerDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { newerDate, olderDate }.AsQueryable();
+            string nestedProperty = "TimeOfDay.Ticks";
+
+            // Act
+            var result = queryable.OrderBy<DateTime>(nestedProperty, OrderByDirection.Ascending);
+
+            // Assert
+            result.First().ShouldBe(olderDate);
+        }
+
+        [Fact]
+        public void OrderBy_When_OrderedDescending_With_Nested_Property_Returns_List_Ordered_Descending()
+        {
+            // Arrange
+            var olderDate = DateTime.MinValue;
+            var newerDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { olderDate, newerDate }.AsQueryable();
+            string nestedProperty = "TimeOfDay.Ticks";
+
+            // Act
+            var result = queryable.OrderBy<DateTime>(nestedProperty, OrderByDirection.Descending);
+
+            // Assert
+            result.First().ShouldBe(newerDate);
+        }
+
+        #endregion OrderBy
 
         #region PickRandom
 

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
@@ -392,5 +392,126 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         #endregion PickRandom (count)
+
+        #region ThenBy
+
+        [Fact]
+        public void ThenBy_When_Property_DoesNotExist_Throws_ArgumentException()
+        {
+            // Arrange
+            var queryable = new List<DateTime> { DateTime.MinValue, DateTime.MaxValue }.AsQueryable();
+            var orderedQueryable = queryable.OrderBy(s => s.Day);
+            string badPropertyName = "test"; // <-- This property does not exist on the string type.
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => orderedQueryable.ThenBy<DateTime>(badPropertyName));
+        }
+
+        [Fact]
+        public void ThenBy_When_List_IsEmpty_Returns_Empty_List()
+        {
+            // Arrange
+            var queryable = new List<DateTime>().AsQueryable();
+            var orderedQueryable = queryable.OrderBy(s => s.Day);
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>("Day");
+
+            // Assert
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void ThenBy_When_Sorted_In_Ascending_Order_Returns_List_Ordered_Ascending()
+        {
+            // Arrange
+            var minDate = DateTime.Now.AddHours(-1);
+            var midDate = DateTime.Now;
+            var maxDate = DateTime.Now.AddDays(1);
+            var queryable = new List<DateTime> { midDate, maxDate, minDate }.AsQueryable();
+            var orderedQueryable = queryable.OrderBy(date => date.Day);
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>("Hour", OrderByDirection.Ascending);
+
+            // Assert
+            result.First().ShouldBe(minDate);
+            result.Last().ShouldBe(maxDate);
+        }
+
+        [Fact]
+        public void ThenBy_When_Sorted_In_Descending_Order_Returns_List_Ordered_Descending()
+        {
+            // Arrange
+            var minDate = DateTime.Now.AddHours(-1);
+            var midDate = DateTime.Now;
+            var maxDate = DateTime.Now.AddDays(1);
+            var queryable = new List<DateTime> { midDate, minDate, maxDate }.AsQueryable();
+            var orderedQueryable = queryable.OrderByDescending(date => date.Day);
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>("Hour", OrderByDirection.Descending);
+
+            // Assert
+            result.First().ShouldBe(maxDate);
+            result.Last().ShouldBe(minDate);
+        }
+
+        [Fact]
+        public void ThenBy_When_ThenByProperty_IsEmpty_Returns_List_Sorted_Only_By_OrderBy()
+        {
+            // Arrange
+            var minDate = DateTime.MinValue;
+            var maxDate = DateTime.MaxValue;
+            var queryable = new List<DateTime> { maxDate, minDate }.AsQueryable();
+            var orderedQueryable = queryable.OrderBy(date => date.Day);
+            string thenByProperty = string.Empty;
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>(thenByProperty);
+
+            // Assert
+            result.ShouldBeSameAs(orderedQueryable);
+        }
+
+        [Fact]
+        public void ThenBy_When_OrderedAscending_With_Nested_Property_Returns_List_Ordered_Ascending()
+        {
+            // Arrange
+            var minDate = DateTime.Now.AddHours(-1);
+            var midDate = DateTime.Now;
+            var maxDate = DateTime.Now.AddDays(1);
+            var queryable = new List<DateTime> { midDate, minDate, maxDate }.AsQueryable();
+            var orderedQueryable = queryable.OrderBy(date => date.Day);
+            string nestedProperty = "TimeOfDay.Ticks";
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>(nestedProperty, OrderByDirection.Ascending);
+
+            // Assert
+            result.First().ShouldBe(minDate);
+            result.Last().ShouldBe(maxDate);
+        }
+
+        [Fact]
+        public void ThenBy_When_OrderedDescending_With_Nested_Property_Returns_List_Ordered_Descending()
+        {
+            // Arrange
+            var minDate = DateTime.Now.AddHours(-1);
+            var midDate = DateTime.Now;
+            var maxDate = DateTime.Now.AddDays(1);
+            var queryable = new List<DateTime> { midDate, minDate, maxDate }.AsQueryable();
+            var orderedQueryable = queryable.OrderByDescending(date => date.Day);
+            string nestedProperty = "Date.Hour";
+
+            // Act
+            var result = orderedQueryable.ThenBy<DateTime>(nestedProperty, OrderByDirection.Descending);
+
+            // Assert
+            result.First().ShouldBe(maxDate);
+            result.Last().ShouldBe(minDate);
+        }
+
+        #endregion ThenBy
     }
 }


### PR DESCRIPTION
- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)

Resolves #26 

Once thing I noticed that the auto-generated documentation has some differences in preference with double quotes instead of single quotes, and the whitespace is different as well.

I was also unable to get a coverage report locally using the `and-cli dotnet-test` command.