### PR TITLE
Update GetDatabaseName method in IConfigurationRootExtensions to handle Initial Catalog as database property

### DIFF
--- a/src/AndcultureCode.CSharp.Extensions/IConfigurationRootExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IConfigurationRootExtensions.cs
@@ -59,8 +59,10 @@ namespace AndcultureCode.CSharp.Extensions
 
             foreach (var setting in settings)
             {
-                if (!setting.ToLower().TrimStart().StartsWith("database")
-                    && !setting.ToLower().TrimStart().StartsWith("initial catalog"))
+                var settingTrimmed = setting.ToLower().TrimStart();
+
+                if (!settingTrimmed.StartsWith("database") &&
+                    !settingTrimmed.StartsWith("initial catalog"))
                 {
                     continue;
                 }

--- a/src/AndcultureCode.CSharp.Extensions/IConfigurationRootExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IConfigurationRootExtensions.cs
@@ -59,7 +59,8 @@ namespace AndcultureCode.CSharp.Extensions
 
             foreach (var setting in settings)
             {
-                if (!setting.ToLower().TrimStart().StartsWith("database"))
+                if (!setting.ToLower().TrimStart().StartsWith("database")
+                    && !setting.ToLower().TrimStart().StartsWith("initial catalog"))
                 {
                     continue;
                 }

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IConfigurationRootExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IConfigurationRootExtensionsTest.cs
@@ -166,6 +166,39 @@ namespace AndcultureCode.CSharp.Extensions.Tests.Unit.Extensions
             result.ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData("initial catalog")]
+        [InlineData("Initial Catalog")]
+        [InlineData("INitial CAtalOG")]
+        [InlineData(" Initial CATaLOG")]
+        public void GetDatabaseName_When_ConnectionStrings_Section_Contains_PrimaryDatabase_Contains_InitialCatalog_Property_Returns_Value(string databaseKey)
+        {
+            // Arrange
+            var expected = "databaseValue";
+            var valueWithoutProperty = $"Prop1=Value1;{databaseKey}={expected}";
+
+            var apiConfigurationSectionMock = new Mock<IConfigurationSection>();
+            apiConfigurationSectionMock
+                .SetupGet(e => e.Value)
+                .Returns(valueWithoutProperty);
+
+            var connectionsConfigurationSectionMock = new Mock<IConfigurationSection>();
+            connectionsConfigurationSectionMock
+                .Setup(e => e.GetSection(IConfigurationRootExtensions.DEFAULT_DATABASE_KEY))
+                .Returns(apiConfigurationSectionMock.Object);
+
+            var configurationMock = new Mock<IConfigurationRoot>();
+            configurationMock
+                .Setup(e => e.GetSection("ConnectionStrings"))
+                .Returns(connectionsConfigurationSectionMock.Object);
+
+            // Act
+            var result = configurationMock.Object.GetDatabaseName();
+
+            // Assert
+            result.ShouldBe(expected);
+        }
+
         #endregion GetDatabaseName
 
         #region GetVersion


### PR DESCRIPTION
`Initial Catalog` is conventional for connection strings to SQL Server (though it can use either), and is the default property when generating a connection string through `SqlConnectionStringBuilder` (see https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconnectionstringbuilder?view=sqlclient-dotnet-core-2.0)

- [NA] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [x] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
