### PR TITLE
IEnumerable and IQueryable HasValues extension methods

### DIFF
--- a/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
+++ b/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
@@ -1,111 +1,115 @@
 <a name='assembly'></a>
+
 # AndcultureCode.CSharp.Extensions
 
 ## Contents
 
-- [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes')
-  - [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN')
-  - [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID')
-  - [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS')
-  - [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE')
-  - [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID')
-  - [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID')
-- [AssemblyExtensions](#T-AndcultureCode-CSharp-Extensions-AssemblyExtensions 'AndcultureCode.CSharp.Extensions.AssemblyExtensions')
-  - [GetLoadableTypes(assembly)](#M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly- 'AndcultureCode.CSharp.Extensions.AssemblyExtensions.GetLoadableTypes(System.Reflection.Assembly)')
-- [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions')
-  - [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)')
-  - [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)')
-  - [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)')
-  - [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)')
-  - [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)')
-  - [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)')
-  - [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)')
-- [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions 'AndcultureCode.CSharp.Extensions.DateExtensions')
-  - [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)')
-  - [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)')
-  - [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- 'AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)')
-  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)')
-  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)')
-  - [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)')
-  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)')
-  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)')
-- [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions 'AndcultureCode.CSharp.Extensions.DictionaryExtensions')
-  - [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- 'AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)')
-- [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions 'AndcultureCode.CSharp.Extensions.ExpressionExtensions')
-  - [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-  - [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-  - [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
-- [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions')
-  - [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR')
-  - [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-  - [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-  - [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)')
-  - [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)')
-  - [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
-- [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions')
-  - [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)')
-- [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions')
-  - [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE')
-  - [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY')
-  - [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE')
-  - [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY')
-  - [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)')
-  - [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)')
-  - [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)')
-- [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions')
-  - [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0})')
-  - [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
-  - [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})')
-  - [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
-  - [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})')
-  - [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
-  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)')
-  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)')
-  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)')
-  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)')
-  - [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})')
-  - [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)')
-  - [Shuffle\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})')
-- [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions 'AndcultureCode.CSharp.Extensions.IQueryableExtensions')
-  - [AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.AppendOrderByExpression``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection,System.Boolean)')
-  - [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})')
-  - [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})')
-  - [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
-  - [OrderBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.OrderBy``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)')
-  - [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})')
-  - [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)')
-  - [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})')
-  - [ThenBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.ThenBy``1(System.Linq.IOrderedQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)')
-- [OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection')
-  - [Ascending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Ascending')
-  - [Descending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Descending')
-- [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions 'AndcultureCode.CSharp.Extensions.StringExtensions')
-  - [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)')
-  - [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)')
-  - [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)')
-  - [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)')
-  - [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)')
-  - [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)')
-  - [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)')
-  - [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)')
-  - [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)')
-  - [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- 'AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)')
-- [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions 'AndcultureCode.CSharp.Extensions.TypeExtensions')
-  - [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)')
-  - [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)')
-  - [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)')
-  - [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)')
-  - [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)')
-  - [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)')
-  - [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)')
-  - [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
-  - [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
+-   [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes")
+    -   [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN")
+    -   [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID")
+    -   [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS")
+    -   [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE")
+    -   [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID")
+    -   [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID")
+-   [AssemblyExtensions](#T-AndcultureCode-CSharp-Extensions-AssemblyExtensions "AndcultureCode.CSharp.Extensions.AssemblyExtensions")
+    -   [GetLoadableTypes(assembly)](#M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly- "AndcultureCode.CSharp.Extensions.AssemblyExtensions.GetLoadableTypes(System.Reflection.Assembly)")
+-   [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions")
+    -   [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)")
+    -   [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)")
+    -   [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)")
+    -   [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)")
+    -   [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)")
+    -   [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)")
+    -   [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)")
+-   [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions "AndcultureCode.CSharp.Extensions.DateExtensions")
+    -   [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)")
+    -   [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)")
+    -   [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- "AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)")
+    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)")
+    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)")
+    -   [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)")
+    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)")
+    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)")
+-   [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions "AndcultureCode.CSharp.Extensions.DictionaryExtensions")
+    -   [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- "AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)")
+-   [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions "AndcultureCode.CSharp.Extensions.ExpressionExtensions")
+    -   [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+    -   [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+    -   [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
+-   [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions "AndcultureCode.CSharp.Extensions.HttpRequestExtensions")
+    -   [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR")
+    -   [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+    -   [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+    -   [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)")
+    -   [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)")
+    -   [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
+-   [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions")
+    -   [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)")
+-   [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions")
+    -   [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE")
+    -   [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY")
+    -   [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE")
+    -   [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY")
+    -   [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)")
+    -   [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)")
+    -   [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)")
+-   [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions "AndcultureCode.CSharp.Extensions.IEnumerableExtensions")
+    -   [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
+    -   [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
+    -   [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
+    -   [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)")
+    -   [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)")
+    -   [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)")
+    -   [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)")
+    -   [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})")
+    -   [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)")
+    -   [Shuffle\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})")
+-   [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions "AndcultureCode.CSharp.Extensions.IQueryableExtensions")
+    -   [AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.AppendOrderByExpression``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection,System.Boolean)")
+    -   [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-HasValues``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.HasValues``1(System.Linq.IQueryable{``0})")
+    -   [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-HasValues``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.HasValues``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})")
+    -   [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})")
+    -   [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
+    -   [OrderBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.OrderBy``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
+    -   [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})")
+    -   [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)")
+    -   [Shuffle\`\`1()](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})")
+    -   [ThenBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.ThenBy``1(System.Linq.IOrderedQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
+-   [OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")
+    -   [Ascending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Ascending")
+    -   [Descending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Descending")
+-   [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions "AndcultureCode.CSharp.Extensions.StringExtensions")
+    -   [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)")
+    -   [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)")
+    -   [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)")
+    -   [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)")
+    -   [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)")
+    -   [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)")
+    -   [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)")
+    -   [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- "AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)")
+    -   [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- "AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)")
+    -   [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- "AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)")
+-   [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions "AndcultureCode.CSharp.Extensions.TypeExtensions")
+    -   [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)")
+    -   [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)")
+    -   [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)")
+    -   [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)")
+    -   [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)")
+    -   [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)")
+    -   [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)")
+    -   [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
+    -   [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
 
 <a name='T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes'></a>
+
 ## ApiClaimTypes `type`
 
 ##### Namespace
@@ -116,9 +120,10 @@ AndcultureCode.CSharp.Core.Constants
 
 Commonly used Claim types for APIs
 
- TODO: Migrate to AndcultureCode.CSharp.Core
+TODO: Migrate to AndcultureCode.CSharp.Core
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN'></a>
+
 ### IS_SUPER_ADMIN `constants`
 
 ##### Summary
@@ -126,6 +131,7 @@ Commonly used Claim types for APIs
 Is the current user elevated to super admin
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID'></a>
+
 ### ROLE_ID `constants`
 
 ##### Summary
@@ -133,6 +139,7 @@ Is the current user elevated to super admin
 Active Role Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS'></a>
+
 ### ROLE_IDS `constants`
 
 ##### Summary
@@ -140,6 +147,7 @@ Active Role Id
 Available Role Ids
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE'></a>
+
 ### ROLE_TYPE `constants`
 
 ##### Summary
@@ -147,6 +155,7 @@ Available Role Ids
 Active Role Type
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID'></a>
+
 ### USER_ID `constants`
 
 ##### Summary
@@ -154,6 +163,7 @@ Active Role Type
 Current User Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID'></a>
+
 ### USER_LOGIN_ID `constants`
 
 ##### Summary
@@ -161,6 +171,7 @@ Current User Id
 Current User Login Id
 
 <a name='T-AndcultureCode-CSharp-Extensions-AssemblyExtensions'></a>
+
 ## AssemblyExtensions `type`
 
 ##### Namespace
@@ -172,6 +183,7 @@ AndcultureCode.CSharp.Extensions
 Extensions for Assembly
 
 <a name='M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly-'></a>
+
 ### GetLoadableTypes(assembly) `method`
 
 ##### Summary
@@ -180,15 +192,14 @@ Safely returns types that can be loaded from the given assembly
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| assembly | [System.Reflection.Assembly](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Reflection.Assembly 'System.Reflection.Assembly') |  |
+| Name     | Type                                                                                                                                                           | Description |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| assembly | [System.Reflection.Assembly](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Reflection.Assembly "System.Reflection.Assembly") |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions'></a>
+
 ## ClaimsPrincipalExtensions `type`
 
 ##### Namespace
@@ -200,6 +211,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for ClaimsPrincipal
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsAuthenticated(principal) `method`
 
 ##### Summary
@@ -208,15 +220,14 @@ Whether the current user is authenticated
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsSuperAdmin(principal) `method`
 
 ##### Summary
@@ -225,15 +236,14 @@ Retrieves whether the user is a super admin by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### IsUnauthenticated(principal) `method`
 
 ##### Summary
@@ -242,15 +252,14 @@ Whether the current user is unauthenticated
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### RoleId(principal) `method`
 
 ##### Summary
@@ -259,15 +268,14 @@ Retrieves user's current role id by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### RoleIds(principal) `method`
 
 ##### Summary
@@ -276,15 +284,14 @@ Retrieves user's role ids by way of their identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### UserId(principal) `method`
 
 ##### Summary
@@ -293,15 +300,14 @@ Retrieves user's id by way of identity claims
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal-'></a>
+
 ### UserLoginId(principal) `method`
 
 ##### Summary
@@ -310,15 +316,14 @@ Retrieves user's UserLoginId from identity claims.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
+| Name      | Type                                                                                                                                                                                               | Description |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-DateExtensions'></a>
+
 ## DateExtensions `type`
 
 ##### Namespace
@@ -330,6 +335,7 @@ AndcultureCode.CSharp.Extensions
 DateTime/Offset Extensions
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset-'></a>
+
 ### AtEndOfDay(date) `method`
 
 ##### Summary
@@ -338,15 +344,14 @@ Sets and returns the time to 11:59:59 on the given DateTimeOffset.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
+| Name | Type                                                                                                                                            | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset-'></a>
+
 ### AtMidnight(date) `method`
 
 ##### Summary
@@ -356,15 +361,14 @@ Returns the midnight representation of the given DateTimeOffset.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
+| Name | Type                                                                                                                                            | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime-'></a>
+
 ### CalculateAge() `method`
 
 ##### Summary
@@ -376,6 +380,7 @@ Convenience method to calculate an age from a birthdate
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset-'></a>
+
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -388,6 +393,7 @@ LINQ doesn't like optional parameters on methods used in expressions
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean-'></a>
+
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -399,6 +405,7 @@ Provides filtering method for date ranges (excluding time portions)
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32-'></a>
+
 ### SetTime(date,hour,minute,second) `method`
 
 ##### Summary
@@ -407,18 +414,17 @@ Sets the hour, minute, and second on the given DateTimeOffset with the supplied 
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
-| hour | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
-| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
-| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| Name   | Type                                                                                                                                            | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| date   | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
+| hour   | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
+| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
+| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32-'></a>
+
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -430,6 +436,7 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32-'></a>
+
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -441,6 +448,7 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='T-AndcultureCode-CSharp-Extensions-DictionaryExtensions'></a>
+
 ## DictionaryExtensions `type`
 
 ##### Namespace
@@ -452,6 +460,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for Dictionary
 
 <a name='M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean-'></a>
+
 ### Merge\`\`2(left,right,takeLastKey) `method`
 
 ##### Summary
@@ -461,25 +470,24 @@ or last occurrence will be used. See 'takeLastKey'
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| left | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into. |
-| right | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into the left dictionary. |
-| takeLastKey | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Determines whether the value of the last occurrence of a key is used as the final value
-when duplicates are encountered. If false, uses the value of the first occurrence. |
+| Name                                                                               | Type                                                                                                                                                                                                                  | Description                                                                             |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| left                                                                               | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into.                                                           |
+| right                                                                              | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into the left dictionary.                                       |
+| takeLastKey                                                                        | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                            | Determines whether the value of the last occurrence of a key is used as the final value |
+| when duplicates are encountered. If false, uses the value of the first occurrence. |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| TKey |  |
-| TValue |  |
+| Name   | Description |
+| ------ | ----------- |
+| TKey   |             |
+| TValue |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-ExpressionExtensions'></a>
+
 ## ExpressionExtensions `type`
 
 ##### Namespace
@@ -491,6 +499,7 @@ AndcultureCode.CSharp.Extensions
 Expression extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### AndAlso\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -499,22 +508,21 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### AndAlso\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -523,24 +531,23 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### OrElse\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -549,22 +556,21 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### OrElse\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -573,24 +579,23 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
 ### Or\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -599,22 +604,21 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
+| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                       |
+| ---- | --------------------------------- |
+| T    | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
+
 ### Or\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -623,24 +627,23 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
+| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description |
-| ---- | ----------- |
-| T | Type of object in the main filter |
+| Name | Description                                            |
+| ---- | ------------------------------------------------------ |
+| T    | Type of object in the main filter                      |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions'></a>
+
 ## HttpRequestExtensions `type`
 
 ##### Namespace
@@ -652,6 +655,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for HttpRequest
 
 <a name='F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR'></a>
+
 ### X_FORWARDED_FOR `constants`
 
 ##### Summary
@@ -659,26 +663,26 @@ Extension methods for HttpRequest
 Standard X-Header for forwarding IP addresses in varying infrastructures
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### GetCookie(request,name) `method`
 
 ##### Summary
 
 Returns the specified cookie by name
 
- If no cookie is found, returns null
+If no cookie is found, returns null
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to pull the cookie from |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to be returned |
+| Name    | Type                                                                                                                      | Description                           |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to pull the cookie from   |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to be returned |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### GetHeader(request,name) `method`
 
 ##### Summary
@@ -687,12 +691,13 @@ Attempts to retrieve requested header value
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Header name/key |
+| Name    | Type                                                                                                                      | Description     |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |                 |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | Header name/key |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest-'></a>
+
 ### GetIpAddress(request) `method`
 
 ##### Summary
@@ -702,15 +707,14 @@ Ensure you have 'AddForwardedHeaders' enabled in startup.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
+| Name    | Type                                                                                                                      | Description |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest-'></a>
+
 ### GetUserAgent() `method`
 
 ##### Summary
@@ -722,26 +726,26 @@ Requesting user's agent
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
+
 ### HasCookie(request,name) `method`
 
 ##### Summary
 
 Returns whether or not the specified cookie is found in the request
 
- If the cookie is found but its value is null/whitespace, it will return false.
+If the cookie is found but its value is null/whitespace, it will return false.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to check for the cookie |
-| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to check for |
+| Name    | Type                                                                                                                      | Description                         |
+| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to check for the cookie |
+| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to check for |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions'></a>
+
 ## HttpResponseMessageExtensions `type`
 
 ##### Namespace
@@ -753,6 +757,7 @@ AndcultureCode.CSharp.Extensions
 HttpResponseMessage extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage-'></a>
+
 ### FromJson\`\`1(response) `method`
 
 ##### Summary
@@ -761,21 +766,20 @@ Deserializes http response into supplied object
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage 'System.Net.Http.HttpResponseMessage') |  |
+| Name     | Type                                                                                                                                                                                      | Description |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage "System.Net.Http.HttpResponseMessage") |             |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions'></a>
+
 ## IConfigurationRootExtensions `type`
 
 ##### Namespace
@@ -787,6 +791,7 @@ AndcultureCode.CSharp.Extensions
 Extension methods for IConfigurationRoot
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE'></a>
+
 ### CONFIGURATION_VERSION_DEVELOPMENT_VALUE `constants`
 
 ##### Summary
@@ -794,6 +799,7 @@ Extension methods for IConfigurationRoot
 Version value when application is run in development environment
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY'></a>
+
 ### CONFIGURATION_VERSION_KEY `constants`
 
 ##### Summary
@@ -801,6 +807,7 @@ Version value when application is run in development environment
 Key value for build version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE'></a>
+
 ### CONFIGURATION_VERSION_TEMPLATE `constants`
 
 ##### Summary
@@ -808,6 +815,7 @@ Key value for build version number
 Template string replaced with current version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY'></a>
+
 ### DEFAULT_DATABASE_KEY `constants`
 
 ##### Summary
@@ -815,6 +823,7 @@ Template string replaced with current version number
 Default connection string database key
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String-'></a>
+
 ### GetDatabaseConnectionString(configuration,databaseKey) `method`
 
 ##### Summary
@@ -823,12 +832,13 @@ Retrieves web application's primary database connection string
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
-| databaseKey | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
+| databaseKey   | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                   |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot-'></a>
+
 ### GetDatabaseName(configuration) `method`
 
 ##### Summary
@@ -837,11 +847,12 @@ Retrieves the database name of the primary database connection string
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean-'></a>
+
 ### GetVersion(configuration,isDevelopment) `method`
 
 ##### Summary
@@ -850,16 +861,15 @@ Loads and conditionally updates the Version number based upon environment
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
-| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') |  |
+| Name          | Type                                                                                                                                                                      | Description |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
+| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions'></a>
+
 ## IEnumerableExtensions `type`
 
 ##### Namespace
@@ -871,6 +881,7 @@ AndcultureCode.CSharp.Extensions
 IEnumerable extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### HasValues\`\`1() `method`
 
 ##### Summary
@@ -882,6 +893,7 @@ Determines if the source collection is non-null and has values
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+
 ### HasValues\`\`1() `method`
 
 ##### Summary
@@ -893,6 +905,7 @@ Determines if the source collection is non-null and has values
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### IsEmpty\`\`1() `method`
 
 ##### Summary
@@ -904,6 +917,7 @@ Determines if the source list is empty
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+
 ### IsEmpty\`\`1() `method`
 
 ##### Summary
@@ -915,6 +929,7 @@ Determines if the source list is empty
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
@@ -926,6 +941,7 @@ Determines if the source list is null or empty
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+
 ### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
@@ -937,6 +953,7 @@ Determines if the source list is null or empty
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String-'></a>
+
 ### Join() `method`
 
 ##### Summary
@@ -948,6 +965,7 @@ Convenience method so joining strings reads better :)
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String-'></a>
+
 ### Join() `method`
 
 ##### Summary
@@ -959,6 +977,7 @@ Convenience method for joining dictionary key values into a string
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String-'></a>
+
 ### Join() `method`
 
 ##### Summary
@@ -970,6 +989,7 @@ Convenience method so joining a list of strings
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String-'></a>
+
 ### Join() `method`
 
 ##### Summary
@@ -981,6 +1001,7 @@ Convenience method for joining key value pairs
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### PickRandom\`\`1() `method`
 
 ##### Summary
@@ -992,6 +1013,7 @@ Returns a random value in the related IEnumerable list
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32-'></a>
+
 ### PickRandom\`\`1() `method`
 
 ##### Summary
@@ -1003,6 +1025,7 @@ Returns X number of random values in the related IEnumerable list
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+
 ### Shuffle\`\`1() `method`
 
 ##### Summary
@@ -1014,6 +1037,7 @@ Returns source enumerable in randomized order
 This method has no parameters.
 
 <a name='T-AndcultureCode-CSharp-Extensions-IQueryableExtensions'></a>
+
 ## IQueryableExtensions `type`
 
 ##### Namespace
@@ -1025,6 +1049,7 @@ AndcultureCode.CSharp.Extensions
 IQueryable extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean-'></a>
+
 ### AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy) `method`
 
 ##### Summary
@@ -1033,118 +1058,95 @@ Adds an additional sorting expression to the supplied IQueryable.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| query | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') | The IQueryable to add additional sorting to. |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
-| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
-| isAdditionalOrderBy | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Whether the order by is an addition to an existing OrderBy statement. |
+| Name                | Type                                                                                                                                                                                                          | Description                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| query               | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") | The IQueryable to add additional sorting to. |
+| propertyName        | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                       | The path to the property to order by (e.g. Path.To.Property).         |
+| direction           | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")          | Order by which to sort items.                                         |
+| isAdditionalOrderBy | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                    | Whether the order by is an addition to an existing OrderBy statement. |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
+
+<a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-HasValues``1-System-Linq-IQueryable{``0}-'></a>
+
+### HasValues\`\`1() `method`
+
+##### Summary
+
+Determines if the source collection is non-null and has values
+
+##### Parameters
+
+This method has no parameters.
+
+<a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-HasValues``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
+
+### HasValues\`\`1() `method`
+
+##### Summary
+
+Determines if the source collection is non-null and has values
+
+##### Parameters
+
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}-'></a>
-### IsEmpty\`\`1(source) `method`
+
+### IsEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is empty
 
-##### Returns
-
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-### IsEmpty\`\`1(source,predicate) `method`
+
+### IsEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is empty (based on the given predicate)
 
-##### Returns
-
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}-'></a>
-### IsNullOrEmpty\`\`1(source) `method`
+
+### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is null or empty
 
-##### Returns
-
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-### IsNullOrEmpty\`\`1(source,predicate) `method`
+
+### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is null or empty (based on the given predicate)
 
-##### Returns
-
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
+
 ### OrderBy\`\`1(query,propertyName,direction) `method`
 
 ##### Summary
@@ -1153,23 +1155,22 @@ Order by the string expression provided.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| query | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') | The IOrderedQueryable to add additional sorting to. |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
-| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
+| Name         | Type                                                                                                                                                                                                                 | Description                                                   |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| query        | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") | The IOrderedQueryable to add additional sorting to. |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                              | The path to the property to order by (e.g. Path.To.Property). |
+| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")                 | Order by which to sort items.                                 |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}-'></a>
+
 ### PickRandom\`\`1(source) `method`
 
 ##### Summary
@@ -1178,18 +1179,19 @@ Returns a random value in the related IQueryable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| Name   | Type                                                                                                                                                           | Description |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32-'></a>
-### PickRandom\`\`1(source,count) `method`
+
+### PickRandom\`\`1() `method`
 
 ##### Summary
 
@@ -1197,19 +1199,11 @@ Returns X number of random values in the related IQueryable list
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}-'></a>
-### Shuffle\`\`1(source) `method`
+
+### Shuffle\`\`1() `method`
 
 ##### Summary
 
@@ -1217,17 +1211,10 @@ Returns source enumerable in randomized order
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T |  |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
+
 ### ThenBy\`\`1(query,propertyName,direction) `method`
 
 ##### Summary
@@ -1236,23 +1223,22 @@ Order then by the string expression provided.
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| query | [System.Linq.IOrderedQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedQueryable 'System.Linq.IOrderedQueryable{``0}') | The IOrderedQueryable to add additional sorting to. |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
-| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
+| Name         | Type                                                                                                                                                                                                                                      | Description                                                   |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| query        | [System.Linq.IOrderedQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedQueryable "System.Linq.IOrderedQueryable{``0}") | The IOrderedQueryable to add additional sorting to. |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                   | The path to the property to order by (e.g. Path.To.Property). |
+| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")                                      | Order by which to sort items.                                 |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T |  |
+| T    |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection'></a>
+
 ## OrderByDirection `type`
 
 ##### Namespace
@@ -1264,6 +1250,7 @@ AndcultureCode.CSharp.Extensions.Enumerations
 Directions for ordering items.
 
 <a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending'></a>
+
 ### Ascending `constants`
 
 ##### Summary
@@ -1271,6 +1258,7 @@ Directions for ordering items.
 Sorted in ascending order.
 
 <a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending'></a>
+
 ### Descending `constants`
 
 ##### Summary
@@ -1278,6 +1266,7 @@ Sorted in ascending order.
 Sorted in descending order.
 
 <a name='T-AndcultureCode-CSharp-Extensions-StringExtensions'></a>
+
 ## StringExtensions `type`
 
 ##### Namespace
@@ -1289,6 +1278,7 @@ AndcultureCode.CSharp.Extensions
 String extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String-'></a>
+
 ### AsIndentedJson(str) `method`
 
 ##### Summary
@@ -1297,34 +1287,32 @@ Formats string for pretty printing of a JSON string
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| str | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name | Type                                                                                                                    | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| str  | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String-'></a>
+
 ### IsInvalidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is not a valid HTTP or HTTPS Url
 
- Uses the native Uri class
+Uses the native Uri class
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name   | Type                                                                                                                    | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String-'></a>
+
 ### IsNotValidGuid(guidString) `method`
 
 ##### Summary
@@ -1333,15 +1321,14 @@ Determine if supplied string is not a valid Guid
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name       | Type                                                                                                                    | Description |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String-'></a>
+
 ### IsValidEmail(email) `method`
 
 ##### Summary
@@ -1350,11 +1337,12 @@ Determines if the supplied string is an email address
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name  | Type                                                                                                                    | Description |
+| ----- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String-'></a>
+
 ### IsValidGuid(guidString) `method`
 
 ##### Summary
@@ -1363,30 +1351,30 @@ Determine if supplied string is a valid Guid
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name       | Type                                                                                                                    | Description |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String-'></a>
+
 ### IsValidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is a valid HTTP or HTTPS url
 
- Uses the native Uri class
+Uses the native Uri class
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name   | Type                                                                                                                    | Description |
+| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String-'></a>
+
 ### ToBoolean() `method`
 
 ##### Summary
@@ -1398,6 +1386,7 @@ Converts a string representation of a boolean into an actual boolean
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char-'></a>
+
 ### ToEnumerable\`\`1(input,separator) `method`
 
 ##### Summary
@@ -1406,16 +1395,15 @@ Converts a string of ints into an enumerable
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| input | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
-| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char 'System.Char') |  |
+| Name      | Type                                                                                                                    | Description |
+| --------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| input     | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char "System.Char")       |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32-'></a>
+
 ### ToInt(number,defaultValue) `method`
 
 ##### Summary
@@ -1428,12 +1416,13 @@ Converted string as an integer value
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| number | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | String that should be a number |
-| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Default value used if the number cannot be parse (0 is default) |
+| Name         | Type                                                                                                                    | Description                                                     |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| number       | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") | String that should be a number                                  |
+| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")    | Default value used if the number cannot be parse (0 is default) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type-'></a>
+
 ### TryChangeType(value,conversionType) `method`
 
 ##### Summary
@@ -1442,16 +1431,15 @@ Returns true or false if the value can be converted
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| value | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| Name           | Type                                                                                                                    | Description |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| value          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
 
 <a name='T-AndcultureCode-CSharp-Extensions-TypeExtensions'></a>
+
 ## TypeExtensions `type`
 
 ##### Namespace
@@ -1463,6 +1451,7 @@ AndcultureCode.CSharp.Extensions
 Extensions for Type
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type-'></a>
+
 ### GetPublicConstantValues\`\`1() `method`
 
 ##### Summary
@@ -1474,6 +1463,7 @@ Retrieve all constant values for given type whose value matches type T
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String-'></a>
+
 ### GetPublicPropertyInfo(type,propertyName) `method`
 
 ##### Summary
@@ -1488,12 +1478,13 @@ The PropertyInfo for the property, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String-'></a>
+
 ### GetPublicPropertyValue(src,propertyName) `method`
 
 ##### Summary
@@ -1508,12 +1499,13 @@ The property value, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String-'></a>
+
 ### GetPublicPropertyValue\`\`1(src,propertyName) `method`
 
 ##### Summary
@@ -1528,12 +1520,13 @@ The property value, if it exists, null otherwise.
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object-'></a>
+
 ### GetTypeName(obj) `method`
 
 ##### Summary
@@ -1542,15 +1535,14 @@ Returns the name the underlying type of any object
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| obj | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| Name | Type                                                                                                                    | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| obj  | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type-'></a>
+
 ### GetTypeName(type) `method`
 
 ##### Summary
@@ -1559,15 +1551,14 @@ Returns the full name of the type as well as the assembly qualified name
 
 ##### Returns
 
-
-
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| Name | Type                                                                                                              | Description |
+| ---- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
+| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String-'></a>
+
 ### HasPublicProperty(type,propertyName) `method`
 
 ##### Summary
@@ -1581,12 +1572,13 @@ true if type has property with specified name, false otherwise
 
 ##### Parameters
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| Name         | Type                                                                                                                    | Description |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
+| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
+
 ### WhereWithAttribute\`\`1() `method`
 
 ##### Summary
@@ -1599,6 +1591,7 @@ decorated with the TAttribute attribute at the class level.
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
+
 ### WhereWithoutAttribute\`\`1() `method`
 
 ##### Summary

--- a/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
+++ b/src/AndcultureCode.CSharp.Extensions/AndcultureCode.CSharp.Extensions.md
@@ -1,111 +1,111 @@
 <a name='assembly'></a>
-
 # AndcultureCode.CSharp.Extensions
 
 ## Contents
 
--   [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes")
-    -   [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN")
-    -   [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID")
-    -   [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS")
-    -   [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE")
-    -   [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID")
-    -   [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID "AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID")
--   [AssemblyExtensions](#T-AndcultureCode-CSharp-Extensions-AssemblyExtensions "AndcultureCode.CSharp.Extensions.AssemblyExtensions")
-    -   [GetLoadableTypes(assembly)](#M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly- "AndcultureCode.CSharp.Extensions.AssemblyExtensions.GetLoadableTypes(System.Reflection.Assembly)")
--   [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions")
-    -   [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)")
-    -   [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)")
-    -   [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)")
-    -   [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)")
-    -   [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)")
-    -   [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)")
-    -   [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- "AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)")
--   [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions "AndcultureCode.CSharp.Extensions.DateExtensions")
-    -   [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)")
-    -   [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)")
-    -   [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- "AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)")
-    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)")
-    -   [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- "AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)")
-    -   [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)")
-    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)")
-    -   [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- "AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)")
--   [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions "AndcultureCode.CSharp.Extensions.DictionaryExtensions")
-    -   [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- "AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)")
--   [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions "AndcultureCode.CSharp.Extensions.ExpressionExtensions")
-    -   [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
-    -   [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
-    -   [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
-    -   [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
-    -   [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
-    -   [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- "AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})")
--   [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions "AndcultureCode.CSharp.Extensions.HttpRequestExtensions")
-    -   [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR")
-    -   [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
-    -   [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
-    -   [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)")
-    -   [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)")
-    -   [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- "AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)")
--   [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions")
-    -   [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- "AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)")
--   [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions")
-    -   [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE")
-    -   [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY")
-    -   [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE")
-    -   [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY")
-    -   [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)")
-    -   [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)")
-    -   [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- "AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)")
--   [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions "AndcultureCode.CSharp.Extensions.IEnumerableExtensions")
-    -   [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})")
-    -   [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
-    -   [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})")
-    -   [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})")
-    -   [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)")
-    -   [Join(list,keyValueDelimiter,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)")
-    -   [Join(list,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)")
-    -   [Join(pair,delimiter)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)")
-    -   [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})")
-    -   [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)")
-    -   [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- "AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})")
--   [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions "AndcultureCode.CSharp.Extensions.IQueryableExtensions")
-    -   [AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.AppendOrderByExpression``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection,System.Boolean)")
-    -   [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})")
-    -   [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
-    -   [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})")
-    -   [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})")
-    -   [OrderBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.OrderBy``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
-    -   [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})")
-    -   [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)")
-    -   [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})")
-    -   [ThenBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- "AndcultureCode.CSharp.Extensions.IQueryableExtensions.ThenBy``1(System.Linq.IOrderedQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)")
--   [OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")
-    -   [Ascending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Ascending")
-    -   [Descending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Descending")
--   [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions "AndcultureCode.CSharp.Extensions.StringExtensions")
-    -   [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)")
-    -   [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)")
-    -   [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)")
-    -   [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)")
-    -   [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)")
-    -   [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)")
-    -   [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- "AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)")
-    -   [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- "AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)")
-    -   [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- "AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)")
-    -   [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- "AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)")
--   [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions "AndcultureCode.CSharp.Extensions.TypeExtensions")
-    -   [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)")
-    -   [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)")
-    -   [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)")
-    -   [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)")
-    -   [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)")
-    -   [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- "AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)")
-    -   [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- "AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)")
-    -   [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
-    -   [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- "AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})")
+- [ApiClaimTypes](#T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes')
+  - [IS_SUPER_ADMIN](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.IS_SUPER_ADMIN')
+  - [ROLE_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_ID')
+  - [ROLE_IDS](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_IDS')
+  - [ROLE_TYPE](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.ROLE_TYPE')
+  - [USER_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_ID')
+  - [USER_LOGIN_ID](#F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID 'AndcultureCode.CSharp.Core.Constants.ApiClaimTypes.USER_LOGIN_ID')
+- [AssemblyExtensions](#T-AndcultureCode-CSharp-Extensions-AssemblyExtensions 'AndcultureCode.CSharp.Extensions.AssemblyExtensions')
+  - [GetLoadableTypes(assembly)](#M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly- 'AndcultureCode.CSharp.Extensions.AssemblyExtensions.GetLoadableTypes(System.Reflection.Assembly)')
+- [ClaimsPrincipalExtensions](#T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions')
+  - [IsAuthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsAuthenticated(System.Security.Claims.ClaimsPrincipal)')
+  - [IsSuperAdmin(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsSuperAdmin(System.Security.Claims.ClaimsPrincipal)')
+  - [IsUnauthenticated(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.IsUnauthenticated(System.Security.Claims.ClaimsPrincipal)')
+  - [RoleId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleId(System.Security.Claims.ClaimsPrincipal)')
+  - [RoleIds(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.RoleIds(System.Security.Claims.ClaimsPrincipal)')
+  - [UserId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserId(System.Security.Claims.ClaimsPrincipal)')
+  - [UserLoginId(principal)](#M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal- 'AndcultureCode.CSharp.Extensions.ClaimsPrincipalExtensions.UserLoginId(System.Security.Claims.ClaimsPrincipal)')
+- [DateExtensions](#T-AndcultureCode-CSharp-Extensions-DateExtensions 'AndcultureCode.CSharp.Extensions.DateExtensions')
+  - [AtEndOfDay(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtEndOfDay(System.DateTimeOffset)')
+  - [AtMidnight(date)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.AtMidnight(System.DateTimeOffset)')
+  - [CalculateAge()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime- 'AndcultureCode.CSharp.Extensions.DateExtensions.CalculateAge(System.DateTime)')
+  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset)')
+  - [IsBetweenDates()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean- 'AndcultureCode.CSharp.Extensions.DateExtensions.IsBetweenDates(System.DateTimeOffset,System.DateTimeOffset,System.DateTimeOffset,System.Boolean)')
+  - [SetTime(date,hour,minute,second)](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SetTime(System.DateTimeOffset,System.Int32,System.Int32,System.Int32)')
+  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTime,System.Int32)')
+  - [SubtractWeekdays()](#M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32- 'AndcultureCode.CSharp.Extensions.DateExtensions.SubtractWeekdays(System.DateTimeOffset,System.Int32)')
+- [DictionaryExtensions](#T-AndcultureCode-CSharp-Extensions-DictionaryExtensions 'AndcultureCode.CSharp.Extensions.DictionaryExtensions')
+  - [Merge\`\`2(left,right,takeLastKey)](#M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean- 'AndcultureCode.CSharp.Extensions.DictionaryExtensions.Merge``2(System.Collections.Generic.Dictionary{``0,``1},System.Collections.Generic.Dictionary{``0,``1},System.Boolean)')
+- [ExpressionExtensions](#T-AndcultureCode-CSharp-Extensions-ExpressionExtensions 'AndcultureCode.CSharp.Extensions.ExpressionExtensions')
+  - [AndAlso\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
+  - [AndAlso\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.AndAlso``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
+  - [OrElse\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
+  - [OrElse\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.OrElse``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
+  - [Or\`\`1(expr1,expr2)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``1(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
+  - [Or\`\`2(expr1,expr2,navigationProperty)](#M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}- 'AndcultureCode.CSharp.Extensions.ExpressionExtensions.Or``2(System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}},System.Linq.Expressions.Expression{System.Func{``0,``1}})')
+- [HttpRequestExtensions](#T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions')
+  - [X_FORWARDED_FOR](#F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.X_FORWARDED_FOR')
+  - [GetCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
+  - [GetHeader(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetHeader(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
+  - [GetIpAddress(request)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetIpAddress(Microsoft.AspNetCore.Http.HttpRequest)')
+  - [GetUserAgent()](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.GetUserAgent(Microsoft.AspNetCore.Http.HttpRequest)')
+  - [HasCookie(request,name)](#M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String- 'AndcultureCode.CSharp.Extensions.HttpRequestExtensions.HasCookie(Microsoft.AspNetCore.Http.HttpRequest,System.String)')
+- [HttpResponseMessageExtensions](#T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions')
+  - [FromJson\`\`1(response)](#M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage- 'AndcultureCode.CSharp.Extensions.HttpResponseMessageExtensions.FromJson``1(System.Net.Http.HttpResponseMessage)')
+- [IConfigurationRootExtensions](#T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions')
+  - [CONFIGURATION_VERSION_DEVELOPMENT_VALUE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_DEVELOPMENT_VALUE')
+  - [CONFIGURATION_VERSION_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_KEY')
+  - [CONFIGURATION_VERSION_TEMPLATE](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.CONFIGURATION_VERSION_TEMPLATE')
+  - [DEFAULT_DATABASE_KEY](#F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.DEFAULT_DATABASE_KEY')
+  - [GetDatabaseConnectionString(configuration,databaseKey)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseConnectionString(Microsoft.Extensions.Configuration.IConfigurationRoot,System.String)')
+  - [GetDatabaseName(configuration)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetDatabaseName(Microsoft.Extensions.Configuration.IConfigurationRoot)')
+  - [GetVersion(configuration,isDevelopment)](#M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean- 'AndcultureCode.CSharp.Extensions.IConfigurationRootExtensions.GetVersion(Microsoft.Extensions.Configuration.IConfigurationRoot,System.Boolean)')
+- [IEnumerableExtensions](#T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions')
+  - [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0})')
+  - [HasValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.HasValues``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
+  - [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0})')
+  - [IsEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
+  - [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0})')
+  - [IsNullOrEmpty\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.IsNullOrEmpty``1(System.Collections.Generic.IEnumerable{``0},System.Func{``0,System.Boolean})')
+  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.String},System.String)')
+  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}},System.String,System.String)')
+  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.List{System.String},System.String)')
+  - [Join()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Join(System.Collections.Generic.KeyValuePair{System.String,System.String},System.String)')
+  - [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0})')
+  - [PickRandom\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.PickRandom``1(System.Collections.Generic.IEnumerable{``0},System.Int32)')
+  - [Shuffle\`\`1()](#M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}- 'AndcultureCode.CSharp.Extensions.IEnumerableExtensions.Shuffle``1(System.Collections.Generic.IEnumerable{``0})')
+- [IQueryableExtensions](#T-AndcultureCode-CSharp-Extensions-IQueryableExtensions 'AndcultureCode.CSharp.Extensions.IQueryableExtensions')
+  - [AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.AppendOrderByExpression``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection,System.Boolean)')
+  - [IsEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0})')
+  - [IsEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
+  - [IsNullOrEmpty\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0})')
+  - [IsNullOrEmpty\`\`1(source,predicate)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.IsNullOrEmpty``1(System.Linq.IQueryable{``0},System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}})')
+  - [OrderBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.OrderBy``1(System.Linq.IQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)')
+  - [PickRandom\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0})')
+  - [PickRandom\`\`1(source,count)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.PickRandom``1(System.Linq.IQueryable{``0},System.Int32)')
+  - [Shuffle\`\`1(source)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.Shuffle``1(System.Linq.IQueryable{``0})')
+  - [ThenBy\`\`1(query,propertyName,direction)](#M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection- 'AndcultureCode.CSharp.Extensions.IQueryableExtensions.ThenBy``1(System.Linq.IOrderedQueryable{``0},System.String,AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection)')
+- [OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection')
+  - [Ascending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Ascending')
+  - [Descending](#F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection.Descending')
+- [StringExtensions](#T-AndcultureCode-CSharp-Extensions-StringExtensions 'AndcultureCode.CSharp.Extensions.StringExtensions')
+  - [AsIndentedJson(str)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.AsIndentedJson(System.String)')
+  - [IsInvalidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsInvalidHttpUrl(System.String)')
+  - [IsNotValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsNotValidGuid(System.String)')
+  - [IsValidEmail(email)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidEmail(System.String)')
+  - [IsValidGuid(guidString)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidGuid(System.String)')
+  - [IsValidHttpUrl(source)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.IsValidHttpUrl(System.String)')
+  - [ToBoolean()](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToBoolean(System.String)')
+  - [ToEnumerable\`\`1(input,separator)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToEnumerable``1(System.String,System.Char)')
+  - [ToInt(number,defaultValue)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32- 'AndcultureCode.CSharp.Extensions.StringExtensions.ToInt(System.String,System.Int32)')
+  - [TryChangeType(value,conversionType)](#M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type- 'AndcultureCode.CSharp.Extensions.StringExtensions.TryChangeType(System.Object,System.Type)')
+- [TypeExtensions](#T-AndcultureCode-CSharp-Extensions-TypeExtensions 'AndcultureCode.CSharp.Extensions.TypeExtensions')
+  - [GetPublicConstantValues\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicConstantValues``1(System.Type)')
+  - [GetPublicPropertyInfo(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyInfo(System.Type,System.String)')
+  - [GetPublicPropertyValue(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue(System.Object,System.String)')
+  - [GetPublicPropertyValue\`\`1(src,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetPublicPropertyValue``1(System.Object,System.String)')
+  - [GetTypeName(obj)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Object)')
+  - [GetTypeName(type)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type- 'AndcultureCode.CSharp.Extensions.TypeExtensions.GetTypeName(System.Type)')
+  - [HasPublicProperty(type,propertyName)](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String- 'AndcultureCode.CSharp.Extensions.TypeExtensions.HasPublicProperty(System.Type,System.String)')
+  - [WhereWithAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
+  - [WhereWithoutAttribute\`\`1()](#M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}- 'AndcultureCode.CSharp.Extensions.TypeExtensions.WhereWithoutAttribute``1(System.Collections.Generic.IEnumerable{System.Type})')
 
 <a name='T-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes'></a>
-
 ## ApiClaimTypes `type`
 
 ##### Namespace
@@ -116,10 +116,9 @@ AndcultureCode.CSharp.Core.Constants
 
 Commonly used Claim types for APIs
 
-TODO: Migrate to AndcultureCode.CSharp.Core
+ TODO: Migrate to AndcultureCode.CSharp.Core
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-IS_SUPER_ADMIN'></a>
-
 ### IS_SUPER_ADMIN `constants`
 
 ##### Summary
@@ -127,7 +126,6 @@ TODO: Migrate to AndcultureCode.CSharp.Core
 Is the current user elevated to super admin
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_ID'></a>
-
 ### ROLE_ID `constants`
 
 ##### Summary
@@ -135,7 +133,6 @@ Is the current user elevated to super admin
 Active Role Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_IDS'></a>
-
 ### ROLE_IDS `constants`
 
 ##### Summary
@@ -143,7 +140,6 @@ Active Role Id
 Available Role Ids
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-ROLE_TYPE'></a>
-
 ### ROLE_TYPE `constants`
 
 ##### Summary
@@ -151,7 +147,6 @@ Available Role Ids
 Active Role Type
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_ID'></a>
-
 ### USER_ID `constants`
 
 ##### Summary
@@ -159,7 +154,6 @@ Active Role Type
 Current User Id
 
 <a name='F-AndcultureCode-CSharp-Core-Constants-ApiClaimTypes-USER_LOGIN_ID'></a>
-
 ### USER_LOGIN_ID `constants`
 
 ##### Summary
@@ -167,7 +161,6 @@ Current User Id
 Current User Login Id
 
 <a name='T-AndcultureCode-CSharp-Extensions-AssemblyExtensions'></a>
-
 ## AssemblyExtensions `type`
 
 ##### Namespace
@@ -179,7 +172,6 @@ AndcultureCode.CSharp.Extensions
 Extensions for Assembly
 
 <a name='M-AndcultureCode-CSharp-Extensions-AssemblyExtensions-GetLoadableTypes-System-Reflection-Assembly-'></a>
-
 ### GetLoadableTypes(assembly) `method`
 
 ##### Summary
@@ -188,14 +180,15 @@ Safely returns types that can be loaded from the given assembly
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name     | Type                                                                                                                                                           | Description |
-| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| assembly | [System.Reflection.Assembly](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Reflection.Assembly "System.Reflection.Assembly") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| assembly | [System.Reflection.Assembly](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Reflection.Assembly 'System.Reflection.Assembly') |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions'></a>
-
 ## ClaimsPrincipalExtensions `type`
 
 ##### Namespace
@@ -207,7 +200,6 @@ AndcultureCode.CSharp.Extensions
 Extension methods for ClaimsPrincipal
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsAuthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### IsAuthenticated(principal) `method`
 
 ##### Summary
@@ -216,14 +208,15 @@ Whether the current user is authenticated
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsSuperAdmin-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### IsSuperAdmin(principal) `method`
 
 ##### Summary
@@ -232,14 +225,15 @@ Retrieves whether the user is a super admin by way of their identity claims
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-IsUnauthenticated-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### IsUnauthenticated(principal) `method`
 
 ##### Summary
@@ -248,14 +242,15 @@ Whether the current user is unauthenticated
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleId-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### RoleId(principal) `method`
 
 ##### Summary
@@ -264,14 +259,15 @@ Retrieves user's current role id by way of their identity claims
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-RoleIds-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### RoleIds(principal) `method`
 
 ##### Summary
@@ -280,14 +276,15 @@ Retrieves user's role ids by way of their identity claims
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserId-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### UserId(principal) `method`
 
 ##### Summary
@@ -296,14 +293,15 @@ Retrieves user's id by way of identity claims
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ClaimsPrincipalExtensions-UserLoginId-System-Security-Claims-ClaimsPrincipal-'></a>
-
 ### UserLoginId(principal) `method`
 
 ##### Summary
@@ -312,14 +310,15 @@ Retrieves user's UserLoginId from identity claims.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                               | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal "System.Security.Claims.ClaimsPrincipal") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| principal | [System.Security.Claims.ClaimsPrincipal](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Security.Claims.ClaimsPrincipal 'System.Security.Claims.ClaimsPrincipal') |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-DateExtensions'></a>
-
 ## DateExtensions `type`
 
 ##### Namespace
@@ -331,7 +330,6 @@ AndcultureCode.CSharp.Extensions
 DateTime/Offset Extensions
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtEndOfDay-System-DateTimeOffset-'></a>
-
 ### AtEndOfDay(date) `method`
 
 ##### Summary
@@ -340,14 +338,15 @@ Sets and returns the time to 11:59:59 on the given DateTimeOffset.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name | Type                                                                                                                                            | Description |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-AtMidnight-System-DateTimeOffset-'></a>
-
 ### AtMidnight(date) `method`
 
 ##### Summary
@@ -357,14 +356,15 @@ Returns the midnight representation of the given DateTimeOffset.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name | Type                                                                                                                                            | Description |
-| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-CalculateAge-System-DateTime-'></a>
-
 ### CalculateAge() `method`
 
 ##### Summary
@@ -376,7 +376,6 @@ Convenience method to calculate an age from a birthdate
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset-'></a>
-
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -389,7 +388,6 @@ LINQ doesn't like optional parameters on methods used in expressions
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-IsBetweenDates-System-DateTimeOffset,System-DateTimeOffset,System-DateTimeOffset,System-Boolean-'></a>
-
 ### IsBetweenDates() `method`
 
 ##### Summary
@@ -401,7 +399,6 @@ Provides filtering method for date ranges (excluding time portions)
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SetTime-System-DateTimeOffset,System-Int32,System-Int32,System-Int32-'></a>
-
 ### SetTime(date,hour,minute,second) `method`
 
 ##### Summary
@@ -410,17 +407,18 @@ Sets the hour, minute, and second on the given DateTimeOffset with the supplied 
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name   | Type                                                                                                                                            | Description |
-| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| date   | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset "System.DateTimeOffset") |             |
-| hour   | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
-| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
-| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                            |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| date | [System.DateTimeOffset](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.DateTimeOffset 'System.DateTimeOffset') |  |
+| hour | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| minute | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
+| second | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTime,System-Int32-'></a>
-
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -432,7 +430,6 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-DateExtensions-SubtractWeekdays-System-DateTimeOffset,System-Int32-'></a>
-
 ### SubtractWeekdays() `method`
 
 ##### Summary
@@ -444,7 +441,6 @@ Convenience method to subtract weekdays
 This method has no parameters.
 
 <a name='T-AndcultureCode-CSharp-Extensions-DictionaryExtensions'></a>
-
 ## DictionaryExtensions `type`
 
 ##### Namespace
@@ -456,7 +452,6 @@ AndcultureCode.CSharp.Extensions
 Extension methods for Dictionary
 
 <a name='M-AndcultureCode-CSharp-Extensions-DictionaryExtensions-Merge``2-System-Collections-Generic-Dictionary{``0,``1},System-Collections-Generic-Dictionary{``0,``1},System-Boolean-'></a>
-
 ### Merge\`\`2(left,right,takeLastKey) `method`
 
 ##### Summary
@@ -466,24 +461,25 @@ or last occurrence will be used. See 'takeLastKey'
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name                                                                               | Type                                                                                                                                                                                                                  | Description                                                                             |
-| ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| left                                                                               | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into.                                                           |
-| right                                                                              | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary "System.Collections.Generic.Dictionary{``0,``1}") | Dictionary to be merged into the left dictionary.                                       |
-| takeLastKey                                                                        | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                            | Determines whether the value of the last occurrence of a key is used as the final value |
-| when duplicates are encountered. If false, uses the value of the first occurrence. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| left | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into. |
+| right | [System.Collections.Generic.Dictionary{\`\`0,\`\`1}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.Dictionary 'System.Collections.Generic.Dictionary{``0,``1}') | Dictionary to be merged into the left dictionary. |
+| takeLastKey | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Determines whether the value of the last occurrence of a key is used as the final value
+when duplicates are encountered. If false, uses the value of the first occurrence. |
 
 ##### Generic Types
 
-| Name   | Description |
-| ------ | ----------- |
-| TKey   |             |
-| TValue |             |
+| Name | Description |
+| ---- | ----------- |
+| TKey |  |
+| TValue |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-ExpressionExtensions'></a>
-
 ## ExpressionExtensions `type`
 
 ##### Namespace
@@ -495,7 +491,6 @@ AndcultureCode.CSharp.Extensions
 Expression extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-
 ### AndAlso\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -504,21 +499,22 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description                       |
-| ---- | --------------------------------- |
-| T    | Type of object in the main filter |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-AndAlso``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
-
 ### AndAlso\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -527,23 +523,24 @@ Adds another expression filter to original expression using AndAlso operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
-| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description                                            |
-| ---- | ------------------------------------------------------ |
-| T    | Type of object in the main filter                      |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-
 ### OrElse\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -552,21 +549,22 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description                       |
-| ---- | --------------------------------- |
-| T    | Type of object in the main filter |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-OrElse``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
-
 ### OrElse\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -575,23 +573,24 @@ Adds another expression filter to original expression using OrElse operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
-| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description                                            |
-| ---- | ------------------------------------------------------ |
-| T    | Type of object in the main filter                      |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``1-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-
 ### Or\`\`1(expr1,expr2) `method`
 
 ##### Summary
@@ -600,21 +599,22 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name  | Type                                                                                                                                                                                                                                                                                                                                        | Description |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                                         |
-| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Additional filter expression on the same type of object as the main expression |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Additional filter expression on the same type of object as the main expression |
 
 ##### Generic Types
 
-| Name | Description                       |
-| ---- | --------------------------------- |
-| T    | Type of object in the main filter |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 
 <a name='M-AndcultureCode-CSharp-Extensions-ExpressionExtensions-Or``2-System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``1,System-Boolean}},System-Linq-Expressions-Expression{System-Func{``0,``1}}-'></a>
-
 ### Or\`\`2(expr1,expr2,navigationProperty) `method`
 
 ##### Summary
@@ -623,23 +623,24 @@ Adds another expression filter to original expression using Or operator
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name               | Type                                                                                                                                                                                                                                                                                                                  | Description                                                   |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| expr1              | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") | Main filter expression                                   |
-| expr2              | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}") | Filter expression that filters on the navigated property |
-| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,``1}}")                                                                                | Expression to the navigation property (eg e => e.PropA.PropB) |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| expr1 | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') | Main filter expression |
+| expr2 | [System.Linq.Expressions.Expression{System.Func{\`\`1,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``1,System.Boolean}}') | Filter expression that filters on the navigated property |
+| navigationProperty | [System.Linq.Expressions.Expression{System.Func{\`\`0,\`\`1}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,``1}}') | Expression to the navigation property (eg e => e.PropA.PropB) |
 
 ##### Generic Types
 
-| Name | Description                                            |
-| ---- | ------------------------------------------------------ |
-| T    | Type of object in the main filter                      |
+| Name | Description |
+| ---- | ----------- |
+| T | Type of object in the main filter |
 | TNav | Type of the navigation property (can be deeply nested) |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpRequestExtensions'></a>
-
 ## HttpRequestExtensions `type`
 
 ##### Namespace
@@ -651,7 +652,6 @@ AndcultureCode.CSharp.Extensions
 Extension methods for HttpRequest
 
 <a name='F-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-X_FORWARDED_FOR'></a>
-
 ### X_FORWARDED_FOR `constants`
 
 ##### Summary
@@ -659,26 +659,26 @@ Extension methods for HttpRequest
 Standard X-Header for forwarding IP addresses in varying infrastructures
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
-
 ### GetCookie(request,name) `method`
 
 ##### Summary
 
 Returns the specified cookie by name
 
-If no cookie is found, returns null
+ If no cookie is found, returns null
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name    | Type                                                                                                                      | Description                           |
-| ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to pull the cookie from   |
-| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to be returned |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to pull the cookie from |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to be returned |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetHeader-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
-
 ### GetHeader(request,name) `method`
 
 ##### Summary
@@ -687,13 +687,12 @@ Attempts to retrieve requested header value
 
 ##### Parameters
 
-| Name    | Type                                                                                                                      | Description     |
-| ------- | ------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |                 |
-| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | Header name/key |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | Header name/key |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetIpAddress-Microsoft-AspNetCore-Http-HttpRequest-'></a>
-
 ### GetIpAddress(request) `method`
 
 ##### Summary
@@ -703,14 +702,15 @@ Ensure you have 'AddForwardedHeaders' enabled in startup.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name    | Type                                                                                                                      | Description |
-| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-GetUserAgent-Microsoft-AspNetCore-Http-HttpRequest-'></a>
-
 ### GetUserAgent() `method`
 
 ##### Summary
@@ -722,26 +722,26 @@ Requesting user's agent
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpRequestExtensions-HasCookie-Microsoft-AspNetCore-Http-HttpRequest,System-String-'></a>
-
 ### HasCookie(request,name) `method`
 
 ##### Summary
 
 Returns whether or not the specified cookie is found in the request
 
-If the cookie is found but its value is null/whitespace, it will return false.
+ If the cookie is found but its value is null/whitespace, it will return false.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name    | Type                                                                                                                      | Description                         |
-| ------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest "Microsoft.AspNetCore.Http.HttpRequest") | The request to check for the cookie |
-| name    | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")   | The name of the cookie to check for |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| request | [Microsoft.AspNetCore.Http.HttpRequest](#T-Microsoft-AspNetCore-Http-HttpRequest 'Microsoft.AspNetCore.Http.HttpRequest') | The request to check for the cookie |
+| name | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The name of the cookie to check for |
 
 <a name='T-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions'></a>
-
 ## HttpResponseMessageExtensions `type`
 
 ##### Namespace
@@ -753,7 +753,6 @@ AndcultureCode.CSharp.Extensions
 HttpResponseMessage extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-HttpResponseMessageExtensions-FromJson``1-System-Net-Http-HttpResponseMessage-'></a>
-
 ### FromJson\`\`1(response) `method`
 
 ##### Summary
@@ -762,20 +761,21 @@ Deserializes http response into supplied object
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name     | Type                                                                                                                                                                                      | Description |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage "System.Net.Http.HttpResponseMessage") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| response | [System.Net.Http.HttpResponseMessage](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Net.Http.HttpResponseMessage 'System.Net.Http.HttpResponseMessage') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions'></a>
-
 ## IConfigurationRootExtensions `type`
 
 ##### Namespace
@@ -787,7 +787,6 @@ AndcultureCode.CSharp.Extensions
 Extension methods for IConfigurationRoot
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_DEVELOPMENT_VALUE'></a>
-
 ### CONFIGURATION_VERSION_DEVELOPMENT_VALUE `constants`
 
 ##### Summary
@@ -795,7 +794,6 @@ Extension methods for IConfigurationRoot
 Version value when application is run in development environment
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_KEY'></a>
-
 ### CONFIGURATION_VERSION_KEY `constants`
 
 ##### Summary
@@ -803,7 +801,6 @@ Version value when application is run in development environment
 Key value for build version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-CONFIGURATION_VERSION_TEMPLATE'></a>
-
 ### CONFIGURATION_VERSION_TEMPLATE `constants`
 
 ##### Summary
@@ -811,7 +808,6 @@ Key value for build version number
 Template string replaced with current version number
 
 <a name='F-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-DEFAULT_DATABASE_KEY'></a>
-
 ### DEFAULT_DATABASE_KEY `constants`
 
 ##### Summary
@@ -819,7 +815,6 @@ Template string replaced with current version number
 Default connection string database key
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseConnectionString-Microsoft-Extensions-Configuration-IConfigurationRoot,System-String-'></a>
-
 ### GetDatabaseConnectionString(configuration,databaseKey) `method`
 
 ##### Summary
@@ -828,13 +823,12 @@ Retrieves web application's primary database connection string
 
 ##### Parameters
 
-| Name          | Type                                                                                                                                                                      | Description |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
-| databaseKey   | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                   |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
+| databaseKey | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetDatabaseName-Microsoft-Extensions-Configuration-IConfigurationRoot-'></a>
-
 ### GetDatabaseName(configuration) `method`
 
 ##### Summary
@@ -843,12 +837,11 @@ Retrieves the database name of the primary database connection string
 
 ##### Parameters
 
-| Name          | Type                                                                                                                                                                      | Description |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IConfigurationRootExtensions-GetVersion-Microsoft-Extensions-Configuration-IConfigurationRoot,System-Boolean-'></a>
-
 ### GetVersion(configuration,isDevelopment) `method`
 
 ##### Summary
@@ -857,15 +850,16 @@ Loads and conditionally updates the Version number based upon environment
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name          | Type                                                                                                                                                                      | Description |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot "Microsoft.Extensions.Configuration.IConfigurationRoot") |             |
-| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| configuration | [Microsoft.Extensions.Configuration.IConfigurationRoot](#T-Microsoft-Extensions-Configuration-IConfigurationRoot 'Microsoft.Extensions.Configuration.IConfigurationRoot') |  |
+| isDevelopment | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-IEnumerableExtensions'></a>
-
 ## IEnumerableExtensions `type`
 
 ##### Namespace
@@ -876,168 +870,118 @@ AndcultureCode.CSharp.Extensions
 
 IEnumerable extension methods
 
-<a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+<a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+### HasValues\`\`1() `method`
 
-### IsEmpty\`\`1(source) `method`
+##### Summary
+
+Determines if the source collection is non-null and has values
+
+##### Parameters
+
+This method has no parameters.
+
+<a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-HasValues``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
+### HasValues\`\`1() `method`
+
+##### Summary
+
+Determines if the source collection is non-null and has values
+
+##### Parameters
+
+This method has no parameters.
+
+<a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
+### IsEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is empty
 
-##### Returns
-
 ##### Parameters
 
-| Name   | Type                                                                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
-
-### IsEmpty\`\`1(source,predicate) `method`
+### IsEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is empty
 
-##### Returns
-
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                           | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source    | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func "System.Func{``0,System.Boolean}")                                                    |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0}-'></a>
-
-### IsNullOrEmpty\`\`1(source) `method`
+### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is null or empty
 
-##### Returns
-
 ##### Parameters
 
-| Name   | Type                                                                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-IsNullOrEmpty``1-System-Collections-Generic-IEnumerable{``0},System-Func{``0,System-Boolean}-'></a>
-
-### IsNullOrEmpty\`\`1(source,predicate) `method`
+### IsNullOrEmpty\`\`1() `method`
 
 ##### Summary
 
 Determines if the source list is null or empty
 
-##### Returns
-
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                           | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source    | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-| predicate | [System.Func{\`\`0,System.Boolean}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Func "System.Func{``0,System.Boolean}")                                                    |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-String},System-String-'></a>
-
-### Join(list,delimiter) `method`
+### Join() `method`
 
 ##### Summary
 
 Convenience method so joining strings reads better :)
 
-##### Returns
-
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                                             | Description |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| list      | [System.Collections.Generic.IEnumerable{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{System.String}") |             |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                          |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-IEnumerable{System-Collections-Generic-KeyValuePair{System-String,System-String}},System-String,System-String-'></a>
-
-### Join(list,keyValueDelimiter,delimiter) `method`
+### Join() `method`
 
 ##### Summary
 
 Convenience method for joining dictionary key values into a string
 
-##### Returns
-
 ##### Parameters
 
-| Name              | Type                                                                                                                                                                                                                                                                                                                                           | Description |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| list              | [System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{System.Collections.Generic.KeyValuePair{System.String,System.String}}") |             |
-| keyValueDelimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                                                                                                        |             |
-| delimiter         | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                                                                                                        |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-List{System-String},System-String-'></a>
-
-### Join(list,delimiter) `method`
+### Join() `method`
 
 ##### Summary
 
 Convenience method so joining a list of strings
 
-##### Returns
-
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                        | Description |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| list      | [System.Collections.Generic.List{System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.List "System.Collections.Generic.List{System.String}") |             |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                     |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Join-System-Collections-Generic-KeyValuePair{System-String,System-String},System-String-'></a>
-
-### Join(pair,delimiter) `method`
+### Join() `method`
 
 ##### Summary
 
 Convenience method for joining key value pairs
 
-##### Returns
-
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                                                                            | Description |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| pair      | [System.Collections.Generic.KeyValuePair{System.String,System.String}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.KeyValuePair "System.Collections.Generic.KeyValuePair{System.String,System.String}") |             |
-| delimiter | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                                         |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0}-'></a>
-
-### PickRandom\`\`1(source) `method`
+### PickRandom\`\`1() `method`
 
 ##### Summary
 
@@ -1045,19 +989,10 @@ Returns a random value in the related IEnumerable list
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-PickRandom``1-System-Collections-Generic-IEnumerable{``0},System-Int32-'></a>
-
-### PickRandom\`\`1(source,count) `method`
+### PickRandom\`\`1() `method`
 
 ##### Summary
 
@@ -1065,20 +1000,10 @@ Returns X number of random values in the related IEnumerable list
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-| count  | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                                                                                           |             |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-IEnumerableExtensions-Shuffle``1-System-Collections-Generic-IEnumerable{``0}-'></a>
-
-### Shuffle\`\`1(source) `method`
+### Shuffle\`\`1() `method`
 
 ##### Summary
 
@@ -1086,18 +1011,9 @@ Returns source enumerable in randomized order
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Collections.Generic.IEnumerable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Collections.Generic.IEnumerable "System.Collections.Generic.IEnumerable{``0}") |
-
-##### Generic Types
-
-| Name | Description |
-| ---- | ----------- |
-| T    |             |
+This method has no parameters.
 
 <a name='T-AndcultureCode-CSharp-Extensions-IQueryableExtensions'></a>
-
 ## IQueryableExtensions `type`
 
 ##### Namespace
@@ -1109,7 +1025,6 @@ AndcultureCode.CSharp.Extensions
 IQueryable extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-AppendOrderByExpression``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection,System-Boolean-'></a>
-
 ### AppendOrderByExpression\`\`1(query,propertyName,direction,isAdditionalOrderBy) `method`
 
 ##### Summary
@@ -1118,23 +1033,24 @@ Adds an additional sorting expression to the supplied IQueryable.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name                | Type                                                                                                                                                                                                          | Description                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| query               | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") | The IQueryable to add additional sorting to. |
-| propertyName        | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                       | The path to the property to order by (e.g. Path.To.Property).         |
-| direction           | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")          | Order by which to sort items.                                         |
-| isAdditionalOrderBy | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean "System.Boolean")                                                                                    | Whether the order by is an addition to an existing OrderBy statement. |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| query | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') | The IQueryable to add additional sorting to. |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
+| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
+| isAdditionalOrderBy | [System.Boolean](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Boolean 'System.Boolean') | Whether the order by is an addition to an existing OrderBy statement. |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0}-'></a>
-
 ### IsEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -1143,20 +1059,21 @@ Determines if the source list is empty
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name   | Type                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-
 ### IsEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -1165,21 +1082,22 @@ Determines if the source list is empty (based on the given predicate)
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                                                                       | Description |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source    | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}")                                                                                             |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0}-'></a>
-
 ### IsNullOrEmpty\`\`1(source) `method`
 
 ##### Summary
@@ -1188,20 +1106,21 @@ Determines if the source list is null or empty
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name   | Type                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-IsNullOrEmpty``1-System-Linq-IQueryable{``0},System-Linq-Expressions-Expression{System-Func{``0,System-Boolean}}-'></a>
-
 ### IsNullOrEmpty\`\`1(source,predicate) `method`
 
 ##### Summary
@@ -1210,21 +1129,22 @@ Determines if the source list is null or empty (based on the given predicate)
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                                                                                                                                                       | Description |
-| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source    | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}")                                                                                             |
-| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression "System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| predicate | [System.Linq.Expressions.Expression{System.Func{\`\`0,System.Boolean}}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.Expressions.Expression 'System.Linq.Expressions.Expression{System.Func{``0,System.Boolean}}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-OrderBy``1-System-Linq-IQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
-
 ### OrderBy\`\`1(query,propertyName,direction) `method`
 
 ##### Summary
@@ -1233,22 +1153,23 @@ Order by the string expression provided.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name         | Type                                                                                                                                                                                                                 | Description                                                   |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| query        | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") | The IOrderedQueryable to add additional sorting to. |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                              | The path to the property to order by (e.g. Path.To.Property). |
-| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")                 | Order by which to sort items.                                 |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| query | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') | The IOrderedQueryable to add additional sorting to. |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
+| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0}-'></a>
-
 ### PickRandom\`\`1(source) `method`
 
 ##### Summary
@@ -1257,18 +1178,17 @@ Returns a random value in the related IQueryable list
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-PickRandom``1-System-Linq-IQueryable{``0},System-Int32-'></a>
-
 ### PickRandom\`\`1(source,count) `method`
 
 ##### Summary
@@ -1277,19 +1197,18 @@ Returns X number of random values in the related IQueryable list
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
-| count  | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")                                           |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
+| count | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-Shuffle``1-System-Linq-IQueryable{``0}-'></a>
-
 ### Shuffle\`\`1(source) `method`
 
 ##### Summary
@@ -1298,18 +1217,17 @@ Returns source enumerable in randomized order
 
 ##### Parameters
 
-| Name   | Type                                                                                                                                                           | Description |
-| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable "System.Linq.IQueryable{``0}") |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.Linq.IQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IQueryable 'System.Linq.IQueryable{``0}') |  |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-IQueryableExtensions-ThenBy``1-System-Linq-IOrderedQueryable{``0},System-String,AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-'></a>
-
 ### ThenBy\`\`1(query,propertyName,direction) `method`
 
 ##### Summary
@@ -1318,22 +1236,23 @@ Order then by the string expression provided.
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name         | Type                                                                                                                                                                                                                                      | Description                                                   |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| query        | [System.Linq.IOrderedQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedQueryable "System.Linq.IOrderedQueryable{``0}") | The IOrderedQueryable to add additional sorting to. |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String")                                                                                                                   | The path to the property to order by (e.g. Path.To.Property). |
-| direction    | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection "AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection")                                      | Order by which to sort items.                                 |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| query | [System.Linq.IOrderedQueryable{\`\`0}](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Linq.IOrderedQueryable 'System.Linq.IOrderedQueryable{``0}') | The IOrderedQueryable to add additional sorting to. |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to the property to order by (e.g. Path.To.Property). |
+| direction | [AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection](#T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection 'AndcultureCode.CSharp.Extensions.Enumerations.OrderByDirection') | Order by which to sort items. |
 
 ##### Generic Types
 
 | Name | Description |
 | ---- | ----------- |
-| T    |             |
+| T |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection'></a>
-
 ## OrderByDirection `type`
 
 ##### Namespace
@@ -1345,7 +1264,6 @@ AndcultureCode.CSharp.Extensions.Enumerations
 Directions for ordering items.
 
 <a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Ascending'></a>
-
 ### Ascending `constants`
 
 ##### Summary
@@ -1353,7 +1271,6 @@ Directions for ordering items.
 Sorted in ascending order.
 
 <a name='F-AndcultureCode-CSharp-Extensions-Enumerations-OrderByDirection-Descending'></a>
-
 ### Descending `constants`
 
 ##### Summary
@@ -1361,7 +1278,6 @@ Sorted in ascending order.
 Sorted in descending order.
 
 <a name='T-AndcultureCode-CSharp-Extensions-StringExtensions'></a>
-
 ## StringExtensions `type`
 
 ##### Namespace
@@ -1373,7 +1289,6 @@ AndcultureCode.CSharp.Extensions
 String extension methods
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-AsIndentedJson-System-String-'></a>
-
 ### AsIndentedJson(str) `method`
 
 ##### Summary
@@ -1382,32 +1297,34 @@ Formats string for pretty printing of a JSON string
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name | Type                                                                                                                    | Description |
-| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| str  | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| str | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsInvalidHttpUrl-System-String-'></a>
-
 ### IsInvalidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is not a valid HTTP or HTTPS Url
 
-Uses the native Uri class
+ Uses the native Uri class
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name   | Type                                                                                                                    | Description |
-| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsNotValidGuid-System-String-'></a>
-
 ### IsNotValidGuid(guidString) `method`
 
 ##### Summary
@@ -1416,14 +1333,15 @@ Determine if supplied string is not a valid Guid
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name       | Type                                                                                                                    | Description |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidEmail-System-String-'></a>
-
 ### IsValidEmail(email) `method`
 
 ##### Summary
@@ -1432,12 +1350,11 @@ Determines if the supplied string is an email address
 
 ##### Parameters
 
-| Name  | Type                                                                                                                    | Description |
-| ----- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| email | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidGuid-System-String-'></a>
-
 ### IsValidGuid(guidString) `method`
 
 ##### Summary
@@ -1446,30 +1363,30 @@ Determine if supplied string is a valid Guid
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name       | Type                                                                                                                    | Description |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| guidString | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-IsValidHttpUrl-System-String-'></a>
-
 ### IsValidHttpUrl(source) `method`
 
 ##### Summary
 
 Determines if the supplied string is a valid HTTP or HTTPS url
 
-Uses the native Uri class
+ Uses the native Uri class
 
 ##### Parameters
 
-| Name   | Type                                                                                                                    | Description |
-| ------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| source | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToBoolean-System-String-'></a>
-
 ### ToBoolean() `method`
 
 ##### Summary
@@ -1481,7 +1398,6 @@ Converts a string representation of a boolean into an actual boolean
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToEnumerable``1-System-String,System-Char-'></a>
-
 ### ToEnumerable\`\`1(input,separator) `method`
 
 ##### Summary
@@ -1490,15 +1406,16 @@ Converts a string of ints into an enumerable
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name      | Type                                                                                                                    | Description |
-| --------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| input     | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
-| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char "System.Char")       |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| input | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
+| separator | [System.Char](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Char 'System.Char') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-ToInt-System-String,System-Int32-'></a>
-
 ### ToInt(number,defaultValue) `method`
 
 ##### Summary
@@ -1511,13 +1428,12 @@ Converted string as an integer value
 
 ##### Parameters
 
-| Name         | Type                                                                                                                    | Description                                                     |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| number       | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") | String that should be a number                                  |
-| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 "System.Int32")    | Default value used if the number cannot be parse (0 is default) |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| number | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | String that should be a number |
+| defaultValue | [System.Int32](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Int32 'System.Int32') | Default value used if the number cannot be parse (0 is default) |
 
 <a name='M-AndcultureCode-CSharp-Extensions-StringExtensions-TryChangeType-System-Object,System-Type-'></a>
-
 ### TryChangeType(value,conversionType) `method`
 
 ##### Summary
@@ -1526,15 +1442,16 @@ Returns true or false if the value can be converted
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name           | Type                                                                                                                    | Description |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| value          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
-| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| value | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| conversionType | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
 
 <a name='T-AndcultureCode-CSharp-Extensions-TypeExtensions'></a>
-
 ## TypeExtensions `type`
 
 ##### Namespace
@@ -1546,7 +1463,6 @@ AndcultureCode.CSharp.Extensions
 Extensions for Type
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicConstantValues``1-System-Type-'></a>
-
 ### GetPublicConstantValues\`\`1() `method`
 
 ##### Summary
@@ -1558,7 +1474,6 @@ Retrieve all constant values for given type whose value matches type T
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyInfo-System-Type,System-String-'></a>
-
 ### GetPublicPropertyInfo(type,propertyName) `method`
 
 ##### Summary
@@ -1573,13 +1488,12 @@ The PropertyInfo for the property, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name         | Type                                                                                                                    | Description |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue-System-Object,System-String-'></a>
-
 ### GetPublicPropertyValue(src,propertyName) `method`
 
 ##### Summary
@@ -1594,13 +1508,12 @@ The property value, if it exists and is public, null otherwise.
 
 ##### Parameters
 
-| Name         | Type                                                                                                                    | Description |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetPublicPropertyValue``1-System-Object,System-String-'></a>
-
 ### GetPublicPropertyValue\`\`1(src,propertyName) `method`
 
 ##### Summary
@@ -1615,13 +1528,12 @@ The property value, if it exists, null otherwise.
 
 ##### Parameters
 
-| Name         | Type                                                                                                                    | Description |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| src          | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| src | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Object-'></a>
-
 ### GetTypeName(obj) `method`
 
 ##### Summary
@@ -1630,14 +1542,15 @@ Returns the name the underlying type of any object
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name | Type                                                                                                                    | Description |
-| ---- | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| obj  | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object "System.Object") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| obj | [System.Object](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Object 'System.Object') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-GetTypeName-System-Type-'></a>
-
 ### GetTypeName(type) `method`
 
 ##### Summary
@@ -1646,14 +1559,15 @@ Returns the full name of the type as well as the assembly qualified name
 
 ##### Returns
 
+
+
 ##### Parameters
 
-| Name | Type                                                                                                              | Description |
-| ---- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
-| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-HasPublicProperty-System-Type,System-String-'></a>
-
 ### HasPublicProperty(type,propertyName) `method`
 
 ##### Summary
@@ -1667,13 +1581,12 @@ true if type has property with specified name, false otherwise
 
 ##### Parameters
 
-| Name         | Type                                                                                                                    | Description |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| type         | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type "System.Type")       |             |
-| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String "System.String") |             |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| type | [System.Type](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.Type 'System.Type') |  |
+| propertyName | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') |  |
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
-
 ### WhereWithAttribute\`\`1() `method`
 
 ##### Summary
@@ -1686,7 +1599,6 @@ decorated with the TAttribute attribute at the class level.
 This method has no parameters.
 
 <a name='M-AndcultureCode-CSharp-Extensions-TypeExtensions-WhereWithoutAttribute``1-System-Collections-Generic-IEnumerable{System-Type}-'></a>
-
 ### WhereWithoutAttribute\`\`1() `method`
 
 ##### Summary

--- a/src/AndcultureCode.CSharp.Extensions/IEnumerableExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IEnumerableExtensions.cs
@@ -10,99 +10,79 @@ namespace AndcultureCode.CSharp.Extensions
     public static class IEnumerableExtensions
     {
         /// <summary>
+        /// Determines if the source collection is non-null and has values
+        /// </summary>
+        public static bool HasValues<T>(this IEnumerable<T> source) => !source.IsNullOrEmpty();
+
+        /// <summary>
+        /// Determines if the source collection is non-null and has values
+        /// </summary>
+        public static bool HasValues<T>(this IEnumerable<T> source, Func<T, bool> predicate) =>
+            !source.IsNullOrEmpty(predicate);
+
+        /// <summary>
         /// Determines if the source list is empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
         public static bool IsEmpty<T>(this IEnumerable<T> source) => !source.Any();
 
         /// <summary>
         /// Determines if the source list is empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="predicate"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
         public static bool IsEmpty<T>(this IEnumerable<T> source, Func<T, bool> predicate) => !source.Any(predicate);
 
         /// <summary>
         /// Determines if the source list is null or empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
         public static bool IsNullOrEmpty<T>(this IEnumerable<T> source) => source == null || source.IsEmpty();
 
         /// <summary>
         /// Determines if the source list is null or empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="predicate"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static bool IsNullOrEmpty<T>(this IEnumerable<T> source, Func<T, bool> predicate) => source == null || source.IsEmpty(predicate);
+        public static bool IsNullOrEmpty<T>(this IEnumerable<T> source, Func<T, bool> predicate) =>
+            source == null || source.IsEmpty(predicate);
 
         /// <summary>
         /// Convenience method so joining strings reads better :)
         /// </summary>
-        /// <param name="list"></param>
-        /// <param name="delimiter"></param>
-        /// <returns></returns>
-        public static string Join(this IEnumerable<string> list, string delimiter = ", ") => list?.ToList().Join(delimiter);
-        
+        public static string Join(this IEnumerable<string> list, string delimiter = ", ") =>
+            list?.ToList().Join(delimiter);
+
         /// <summary>
         /// Convenience method for joining dictionary key values into a string
         /// </summary>
-        /// <param name="list"></param>
-        /// <param name="keyValueDelimiter"></param>
-        /// <param name="delimiter"></param>
-        /// <returns></returns>
-        public static string Join(this IEnumerable<KeyValuePair<string, string>> list, string keyValueDelimiter, string delimiter = ", ")
-            => list?.Select(e => e.Join(keyValueDelimiter)).Where(e => !string.IsNullOrEmpty(e)).Join(delimiter);
+        public static string Join(
+            this IEnumerable<KeyValuePair<string, string>> list,
+            string keyValueDelimiter,
+            string delimiter = ", "
+        ) => list?.Select(e => e.Join(keyValueDelimiter)).Where(e => !string.IsNullOrEmpty(e)).Join(delimiter);
 
         /// <summary>
         /// Convenience method so joining a list of strings
         /// </summary>
-        /// <param name="list"></param>
-        /// <param name="delimiter"></param>
-        /// <returns></returns>
-        public static string Join(this List<string> list, string delimiter = ", ")
-        {
-            return list == null ? null : string.Join(delimiter, list);
-        }
-        
+        public static string Join(this List<string> list, string delimiter = ", ") =>
+            list == null ? null : string.Join(delimiter, list);
+
         /// <summary>
         /// Convenience method for joining key value pairs
         /// </summary>
-        /// <param name="pair"></param>
-        /// <param name="delimiter"></param>
-        /// <returns></returns>
-        public static string Join(this KeyValuePair<string, string> pair, string delimiter)
-            => new List<string> { pair.Key, pair.Value }
+        public static string Join(this KeyValuePair<string, string> pair, string delimiter) =>
+            new List<string> { pair.Key, pair.Value }
                 .Where(e => !string.IsNullOrEmpty(e))
                 .Join(delimiter);
 
         /// <summary>
         /// Returns a random value in the related IEnumerable list
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
         public static T PickRandom<T>(this IEnumerable<T> source) => source.PickRandom(1).SingleOrDefault();
 
         /// <summary>
         /// Returns X number of random values in the related IEnumerable list
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="count"></param>
-        /// <typeparam name="T"></typeparam>
         public static IEnumerable<T> PickRandom<T>(this IEnumerable<T> source, int count) => source.Shuffle().Take(count);
 
         /// <summary>
         /// Returns source enumerable in randomized order
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
         public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source) => source.OrderBy(x => Guid.NewGuid());
     }
 }

--- a/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
@@ -10,7 +10,6 @@ namespace AndcultureCode.CSharp.Extensions
     /// </summary>
     public static class IQueryableExtensions
     {
-
         /// <summary>
         /// Determines if the source collection is non-null and has values
         /// </summary>

--- a/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
+++ b/src/AndcultureCode.CSharp.Extensions/IQueryableExtensions.cs
@@ -10,39 +10,43 @@ namespace AndcultureCode.CSharp.Extensions
     /// </summary>
     public static class IQueryableExtensions
     {
+
+        /// <summary>
+        /// Determines if the source collection is non-null and has values
+        /// </summary>
+        public static bool HasValues<T>(this IQueryable<T> source) => !source.IsNullOrEmpty();
+
+        /// <summary>
+        /// Determines if the source collection is non-null and has values
+        /// </summary>
+        public static bool HasValues<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) =>
+            !source.IsNullOrEmpty(predicate);
+
         /// <summary>
         /// Determines if the source list is empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
         public static bool IsEmpty<T>(this IQueryable<T> source) => !source.Any();
 
         /// <summary>
         /// Determines if the source list is empty (based on the given predicate)
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="predicate"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static bool IsEmpty<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) => !source.Any(predicate);
+        public static bool IsEmpty<T>(
+            this IQueryable<T> source,
+            Expression<Func<T, bool>> predicate
+        ) => !source.Any(predicate);
 
         /// <summary>
         /// Determines if the source list is null or empty
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
         public static bool IsNullOrEmpty<T>(this IQueryable<T> source) => source == null || source.IsEmpty();
 
         /// <summary>
         /// Determines if the source list is null or empty (based on the given predicate)
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="predicate"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static bool IsNullOrEmpty<T>(this IQueryable<T> source, Expression<Func<T, bool>> predicate) => source == null || source.IsEmpty(predicate);
+        public static bool IsNullOrEmpty<T>(
+            this IQueryable<T> source,
+            Expression<Func<T, bool>> predicate
+        ) => source == null || source.IsEmpty(predicate);
 
         /// <summary>
         /// Order by the string expression provided.
@@ -52,8 +56,11 @@ namespace AndcultureCode.CSharp.Extensions
         /// <param name="direction">Order by which to sort items.</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static IOrderedQueryable<T> OrderBy<T>(this IQueryable<T> query,
-            string propertyName, OrderByDirection direction = OrderByDirection.Ascending) => query.AppendOrderByExpression(propertyName, direction, false);
+        public static IOrderedQueryable<T> OrderBy<T>(
+            this IQueryable<T> query,
+            string propertyName,
+            OrderByDirection direction = OrderByDirection.Ascending
+        ) => query.AppendOrderByExpression(propertyName, direction, false);
 
         /// <summary>
         /// Returns a random value in the related IQueryable list
@@ -65,16 +72,11 @@ namespace AndcultureCode.CSharp.Extensions
         /// <summary>
         /// Returns X number of random values in the related IQueryable list
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="count"></param>
-        /// <typeparam name="T"></typeparam>
         public static IQueryable<T> PickRandom<T>(this IQueryable<T> source, int count) => source.Shuffle().Take(count);
 
         /// <summary>
         /// Returns source enumerable in randomized order
         /// </summary>
-        /// <param name="source"></param>
-        /// <typeparam name="T"></typeparam>
         public static IQueryable<T> Shuffle<T>(this IQueryable<T> source) => source.OrderBy(x => Guid.NewGuid());
 
         /// <summary>
@@ -85,8 +87,11 @@ namespace AndcultureCode.CSharp.Extensions
         /// <param name="direction">Order by which to sort items.</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static IOrderedQueryable<T> ThenBy<T>(this IOrderedQueryable<T> query,
-            string propertyName, OrderByDirection direction = OrderByDirection.Ascending) => query.AppendOrderByExpression(propertyName, direction, true);
+        public static IOrderedQueryable<T> ThenBy<T>(
+            this IOrderedQueryable<T> query,
+            string propertyName,
+            OrderByDirection direction = OrderByDirection.Ascending
+        ) => query.AppendOrderByExpression(propertyName, direction, true);
 
         #region Private Methods
 
@@ -99,7 +104,11 @@ namespace AndcultureCode.CSharp.Extensions
         /// <param name="isAdditionalOrderBy">Whether the order by is an addition to an existing OrderBy statement.</param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        private static IOrderedQueryable<T> AppendOrderByExpression<T>(this IQueryable<T> query, string propertyName, OrderByDirection direction, bool isAdditionalOrderBy)
+        private static IOrderedQueryable<T> AppendOrderByExpression<T>(
+            this IQueryable<T> query,
+            string propertyName, OrderByDirection direction,
+            bool isAdditionalOrderBy
+        )
         {
             if (string.IsNullOrWhiteSpace(propertyName))
             {

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using AndcultureCode.CSharp.Testing.Tests;
@@ -68,9 +67,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IEnumerable<string> source = null;
+            var unexpected = Random.Word();
 
             // Act
-            var result = source.HasValues((e) => e == Random.Word());
+            var result = source.HasValues((e) => e == unexpected);
 
             // Assert
             result.ShouldBeFalse();
@@ -81,9 +81,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IEnumerable<string> source = new List<string>();
+            var unexpected = Random.Word();
 
             // Act
-            var result = source.HasValues((e) => e == Random.Word());
+            var result = source.HasValues((e) => e == unexpected);
 
             // Assert
             result.ShouldBeFalse();
@@ -94,9 +95,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IEnumerable<string> source = Random.WordsArray(1, 3);
+            var unexpected = $"{source.PickRandom()}-nonmatching";
 
             // Act
-            var result = source.HasValues((e) => e == $"{source.PickRandom()}-nonmatching");
+            var result = source.HasValues((e) => e == unexpected);
 
             // Assert
             result.ShouldBeFalse();
@@ -107,9 +109,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IEnumerable<string> source = Random.WordsArray(1, 3);
+            var expected = source.PickRandom();
 
             // Act
-            var result = source.HasValues((e) => e == source.PickRandom());
+            var result = source.HasValues((e) => e == expected);
 
             // Assert
             result.ShouldBeTrue();

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
@@ -145,25 +145,44 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         [Fact]
         public void IsEmpty_Given_Predicate_When_Empty_Returns_True()
         {
-            new List<string>()                    // Arrange
-                .IsEmpty((e) => e == "something") // Act
-                    .ShouldBeTrue();              // Assert
+            // Arrange
+            var source = new List<string>();
+            var unexpected = Random.Word();
+
+            // Act
+            var result = source.IsEmpty((e) => e == unexpected);
+
+            // Assert
+            result.ShouldBeTrue();
         }
 
         [Fact]
         public void IsEmpty_Given_Predicate_When_NotEmpty_When_DoesNotContain_Matches_Returns_True()
         {
-            new List<string> { "something" }   // Arrange
-                .IsEmpty(e => e == "no match") // Act
-                    .ShouldBeTrue();           // Assert
+
+            // Arrange
+            var source = Random.WordsArray(1, 3);
+            var unexpected = $"{source.PickRandom()}-nonmatching";
+
+            // Act
+            var result = source.IsEmpty((e) => e == unexpected);
+
+            // Assert
+            result.ShouldBeTrue();
         }
 
         [Fact]
         public void IsEmpty_Given_Predicate_When_NotEmpty_When_Contains_Matches_Returns_False()
         {
-            new List<string> { "something" }    // Arrange
-                .IsEmpty(e => e == "something") // Act
-                    .ShouldBeFalse();           // Assert
+            // Arrange
+            var source = Random.WordsArray(1, 3);
+            var expected = source.PickRandom();
+
+            // Act
+            var result = source.IsEmpty((e) => e == expected);
+
+            // Assert
+            result.ShouldBeFalse();
         }
 
         #endregion IsEmpty (Given Predicate)

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IEnumerableExtensionsTest.cs
@@ -1,13 +1,122 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AndcultureCode.CSharp.Testing.Tests;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AndcultureCode.CSharp.Extensions.Tests
 {
-    public class IEnumerableExtensionsTest
+    public class IEnumerableExtensionsTest : BaseUnitTest
     {
+        #region Setup
+
+        public IEnumerableExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        #endregion Setup
+
+        #region HasValues (No Arguments)
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_Null_Returns_False()
+        {
+            // Arrange
+            IEnumerable<string> source = null;
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_Empty_Returns_False()
+        {
+            // Arrange
+            IEnumerable<string> source = new List<string>();
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_NotEmpty_Returns_True()
+        {
+            // Arrange
+            IEnumerable<string> source = Random.WordsArray(1, 3);
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        #endregion HasValues (No Arguments)
+
+        #region HasValues (Given Predicate)
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_Null_Returns_False()
+        {
+            // Arrange
+            IEnumerable<string> source = null;
+
+            // Act
+            var result = source.HasValues((e) => e == Random.Word());
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_Empty_Returns_False()
+        {
+            // Arrange
+            IEnumerable<string> source = new List<string>();
+
+            // Act
+            var result = source.HasValues((e) => e == Random.Word());
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_NotEmpty_DoesNotContainMatches_Returns_False()
+        {
+            // Arrange
+            IEnumerable<string> source = Random.WordsArray(1, 3);
+
+            // Act
+            var result = source.HasValues((e) => e == $"{source.PickRandom()}-nonmatching");
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_NotEmpty_ContainsMatch_Returns_True()
+        {
+            // Arrange
+            IEnumerable<string> source = Random.WordsArray(1, 3);
+
+            // Act
+            var result = source.HasValues((e) => e == source.PickRandom());
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        #endregion HasValues (Given Predicate)
+
         #region IsEmpty (No Arguments)
 
         [Fact]
@@ -28,15 +137,14 @@ namespace AndcultureCode.CSharp.Extensions.Tests
 
         #endregion IsEmpty (No Arguments)
 
-
         #region IsEmpty (Given Predicate)
 
         [Fact]
         public void IsEmpty_Given_Predicate_When_Empty_Returns_True()
         {
-            new List<string>()       // Arrange
-                .IsEmpty()           // Act
-                    .ShouldBeTrue(); // Assert
+            new List<string>()                    // Arrange
+                .IsEmpty((e) => e == "something") // Act
+                    .ShouldBeTrue();              // Assert
         }
 
         [Fact]
@@ -56,7 +164,6 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         #endregion IsEmpty (Given Predicate)
-
 
         #region IsNullOrEmpty (No Arguments)
 
@@ -86,18 +193,14 @@ namespace AndcultureCode.CSharp.Extensions.Tests
 
         #endregion IsNullOrEmpty (No Arguments)
 
-
         #region IsNullOrEmpty (Given Predicate)
 
         [Fact]
         public void IsNullOrEmpty_Given_Predicate_When_Null_Returns_True()
         {
-            IEnumerableExtensions                         // Arrange
-                .IsNullOrEmpty<string>(                  // Act
-                        source: null,
-                        predicate: e => true
-                    )
-                    .ShouldBeTrue();                     // Assert
+            ((IEnumerable<string>)null)     // Arrange
+                .IsNullOrEmpty((e) => true) // Act
+                    .ShouldBeTrue();        // Assert
         }
 
         [Fact]
@@ -126,7 +229,6 @@ namespace AndcultureCode.CSharp.Extensions.Tests
 
         #endregion IsNullOrEmpty (Given Predicate)
 
-
         #region Join IEnumerable (Delimiter)
 
         [Fact]
@@ -154,7 +256,6 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         #endregion Join IEnumerable (Delimiter)
-
 
         #region Join List of Strings (Delimiter)
 
@@ -189,49 +290,49 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         [Fact]
         public void Join_KeyValuePair_Given_Key_And_Value_Returns_Key_And_Value_With_Delimiter()
         {
-            (new KeyValuePair<string,string>("key", "value")).Join(delimiter: ":").ShouldBe("key:value");
+            (new KeyValuePair<string, string>("key", "value")).Join(delimiter: ":").ShouldBe("key:value");
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Null_Value_Returns_Key()
         {
-            (new KeyValuePair<string,string>("key", null)).Join(delimiter: ":").ShouldBe("key");
+            (new KeyValuePair<string, string>("key", null)).Join(delimiter: ":").ShouldBe("key");
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Null_Key_Returns_Value()
         {
-            (new KeyValuePair<string,string>(null, "value")).Join(delimiter: ":").ShouldBe("value");
+            (new KeyValuePair<string, string>(null, "value")).Join(delimiter: ":").ShouldBe("value");
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Null_Key_And_Value_Returns_Empty_String()
         {
-            (new KeyValuePair<string,string>(null, null)).Join(delimiter: ":").ShouldBe(string.Empty);
+            (new KeyValuePair<string, string>(null, null)).Join(delimiter: ":").ShouldBe(string.Empty);
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Empty_String_Key_And_Value_Returns_Empty_String()
         {
-            (new KeyValuePair<string,string>(string.Empty, string.Empty)).Join(delimiter: ":").ShouldBe(string.Empty);
+            (new KeyValuePair<string, string>(string.Empty, string.Empty)).Join(delimiter: ":").ShouldBe(string.Empty);
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Empty_String_Key_Returns_Value()
         {
-            (new KeyValuePair<string,string>(string.Empty, "value")).Join(delimiter: ":").ShouldBe("value");
+            (new KeyValuePair<string, string>(string.Empty, "value")).Join(delimiter: ":").ShouldBe("value");
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Empty_String_Value_Returns_Key()
         {
-            (new KeyValuePair<string,string>("key", string.Empty)).Join(delimiter: ":").ShouldBe("key");
+            (new KeyValuePair<string, string>("key", string.Empty)).Join(delimiter: ":").ShouldBe("key");
         }
-        
+
         [Fact]
         public void Join_KeyValuePair_Given_Null_Delimiter_Returns_Key_Value_Without_Delimiter()
         {
-            (new KeyValuePair<string,string>("key", "value")).Join(delimiter: null).ShouldBe("keyvalue");
+            (new KeyValuePair<string, string>("key", "value")).Join(delimiter: null).ShouldBe("keyvalue");
         }
 
         #endregion Join KeyValuePair (Delimiter)
@@ -241,65 +342,65 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_And_Delimiter_Returns_String_Of_Key_Values_With_Delimiter()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>("key2", "value2");
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":", delimiter: "; ").ShouldBe("key1:value1; key2:value2");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>("key2", "value2");
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":", delimiter: "; ").ShouldBe("key1:value1; key2:value2");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_And_No_Delimiter_Returns_String_Of_Key_Values()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>("key2", "value2");
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, key2:value2");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>("key2", "value2");
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, key2:value2");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Null_Value_Returns_String_Of_Key_Values()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>("key2", null);
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, key2");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>("key2", null);
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, key2");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Null_Key_Returns_String_Of_Key_Values()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>(null, "value2");
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, value2");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>(null, "value2");
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1, value2");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Empty_KeyValuePair_Returns_String_Of_Key_Values()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>(string.Empty, string.Empty);
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>(string.Empty, string.Empty);
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Empty_KeyValuePairs_Returns_Empty_String()
         {
-            var keyValue1 = new KeyValuePair<string,string>(string.Empty, string.Empty);
-            var keyValue2 = new KeyValuePair<string,string>(string.Empty, string.Empty);
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe(string.Empty);
+            var keyValue1 = new KeyValuePair<string, string>(string.Empty, string.Empty);
+            var keyValue2 = new KeyValuePair<string, string>(string.Empty, string.Empty);
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe(string.Empty);
         }
-        
+
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Null_KeyValuePair_Returns_String_Of_Key_Values()
         {
-            var keyValue1 = new KeyValuePair<string,string>("key1", "value1");
-            var keyValue2 = new KeyValuePair<string,string>(null, null);
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1");
+            var keyValue1 = new KeyValuePair<string, string>("key1", "value1");
+            var keyValue2 = new KeyValuePair<string, string>(null, null);
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe("key1:value1");
         }
 
         [Fact]
         public void Join_Given_List_Of_KeyValuePairs_With_Null_KeyValuePairs_Returns_Empty_String()
         {
-            var keyValue1 = new KeyValuePair<string,string>(null, null);
-            var keyValue2 = new KeyValuePair<string,string>(null, null);
-            new List<KeyValuePair<string, string>>{ keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe(string.Empty);
+            var keyValue1 = new KeyValuePair<string, string>(null, null);
+            var keyValue2 = new KeyValuePair<string, string>(null, null);
+            new List<KeyValuePair<string, string>> { keyValue1, keyValue2 }.Join(keyValueDelimiter: ":").ShouldBe(string.Empty);
         }
 
         #endregion Join List of KeyValuePair (Delimiter)
@@ -335,7 +436,6 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         }
 
         #endregion PickRandom
-
 
         #region PickRandom (count)
 

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using AndcultureCode.CSharp.Extensions.Enumerations;
 using AndcultureCode.CSharp.Testing.Tests;
 using Shouldly;
@@ -70,9 +69,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IQueryable<string> source = null;
+            var unexpected = Random.Word();
 
             // Act
-            var result = source.HasValues((e) => e == Random.Word());
+            var result = source.HasValues((e) => e == unexpected);
 
             // Assert
             result.ShouldBeFalse();
@@ -83,9 +83,10 @@ namespace AndcultureCode.CSharp.Extensions.Tests
         {
             // Arrange
             IQueryable<string> source = new List<string>().AsQueryable();
+            var unexpected = Random.Word();
 
             // Act
-            var result = source.HasValues((e) => e == Random.Word());
+            var result = source.HasValues((e) => e == unexpected);
 
             // Assert
             result.ShouldBeFalse();

--- a/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
+++ b/test/AndcultureCode.CSharp.Extensions.Tests/IQueryableExtensionsTest.cs
@@ -1,14 +1,126 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using AndcultureCode.CSharp.Extensions.Enumerations;
+using AndcultureCode.CSharp.Testing.Tests;
 using Shouldly;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AndcultureCode.CSharp.Extensions.Tests
 {
-    public class IQueryableExtensionsTest
+    public class IQueryableExtensionsTest : BaseUnitTest
     {
+        #region Setup
+
+        public IQueryableExtensionsTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        #endregion Setup
+
+        #region HasValues (No Arguments)
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_Null_Returns_False()
+        {
+            // Arrange
+            IQueryable<string> source = null;
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_Empty_Returns_False()
+        {
+            // Arrange
+            IQueryable<string> source = new List<string>().AsQueryable();
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_NoArguments_When_NotEmpty_Returns_True()
+        {
+            // Arrange
+            IQueryable<string> source = Random.WordsArray(1, 3).AsQueryable();
+
+            // Act
+            var result = source.HasValues();
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        #endregion HasValues (No Arguments)
+
+        #region HasValues (Given Predicate)
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_Null_Returns_False()
+        {
+            // Arrange
+            IQueryable<string> source = null;
+
+            // Act
+            var result = source.HasValues((e) => e == Random.Word());
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_Empty_Returns_False()
+        {
+            // Arrange
+            IQueryable<string> source = new List<string>().AsQueryable();
+
+            // Act
+            var result = source.HasValues((e) => e == Random.Word());
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_NotEmpty_DoesNotContainMatches_Returns_False()
+        {
+            // Arrange
+            IQueryable<string> source = Random.WordsArray(1, 3).AsQueryable();
+            var unexpected = $"{source.PickRandom()}-nonmatching";
+
+            // Act
+            var result = source.HasValues((e) => e == unexpected);
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void HasValues_Given_Predicate_When_NotEmpty_ContainsMatch_Returns_True()
+        {
+            // Arrange
+            IQueryable<string> source = Random.WordsArray(1, 3).AsQueryable();
+            var expected = source.PickRandom();
+
+            // Act
+            var result = source.HasValues((e) => e == expected);
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+
+        #endregion HasValues (Given Predicate)
+
         #region IsEmpty (No Arguments)
 
         [Fact]


### PR DESCRIPTION
Resolves #51 Extension for inversion of IEnumerable.IsNullOrEmpty 

- [x] Related GitHub issue(s) linked in PR description
- [x] Destination branch merged, built and tested with your changes
- [x] Code formatted and follows best practices and patterns
- [x] Code builds cleanly (no _additional_ warnings or errors)
- [x] Manually tested
- [x] Automated tests are passing
- [x] No _decreases_ in automated test coverage
- [x] Documentation updated (readme, docs, comments, etc.)
- [-] Localization: No hard-coded error messages in code files (_minimally_ in string constants)
